### PR TITLE
ZK-572: Introduce VersionError in ShielderClient

### DIFF
--- a/ts/shielder-sdk-tests/tests/shielder/client.test.ts
+++ b/ts/shielder-sdk-tests/tests/shielder/client.test.ts
@@ -90,7 +90,7 @@ sdkTest(
           },
           onError: (
             error: unknown,
-            stage: "generation" | "sending",
+            stage: "generation" | "sending" | "syncing",
             operation: ShielderOperation,
           ) => {
             if (

--- a/ts/shielder-sdk/package.json
+++ b/ts/shielder-sdk/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "async-mutex": "^0.5.0",
     "comlink": "^4.4.1",
+    "ts-custom-error": "^3.3.1",
     "viem": "^2.21.40",
     "zod": "^3.23.8"
   }

--- a/ts/shielder-sdk/pnpm-lock.yaml
+++ b/ts/shielder-sdk/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       comlink:
         specifier: ^4.4.1
         version: 4.4.1
+      ts-custom-error:
+        specifier: ^3.3.1
+        version: 3.3.1
       viem:
         specifier: ^2.21.40
         version: 2.21.40(typescript@5.6.3)(zod@3.23.8)
@@ -1596,6 +1599,10 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
+
+  ts-custom-error@3.3.1:
+    resolution: {integrity: sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==}
+    engines: {node: '>=14.0.0'}
 
   ts-jest@29.2.5:
     resolution: {integrity: sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==}
@@ -3554,6 +3561,8 @@ snapshots:
   ts-api-utils@1.4.0(typescript@5.6.3):
     dependencies:
       typescript: 5.6.3
+
+  ts-custom-error@3.3.1: {}
 
   ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.7))(typescript@5.6.3):
     dependencies:


### PR DESCRIPTION
Just a copy of https://github.com/Cardinal-Cryptography/zkOS/pull/417 from old `zkOS` repo. We're merging it into our new `zkOS-monorepo`.

We add a single exception type that `ShielderClient` will throw whenever completing the request is impossible due to outdated SDK.

This may happen after contract update, which is a scenario described in [Updating Shielder Contracts and Common Wallet ADR](https://www.notion.so/cardinalcryptography/Updating-Shielder-Contracts-and-Common-Wallet-12faf09db1a98050a6abe671aca3e71d). We also covered some backend details in [Shielder Contract Versioning Implementation ADR](https://www.notion.so/cardinalcryptography/Shielder-Contract-Versioning-Implementation-13eaf09db1a98056ad0de203914386fb).