### PR TITLE
ZK-559: fix vite workers (wasm generation part)

### DIFF
--- a/crates/shielder-wasm/Makefile
+++ b/crates/shielder-wasm/Makefile
@@ -1,11 +1,3 @@
-# `sed -i` is used differently under MacOS
-OS := $(shell uname)
-ifeq ($(OS), Darwin)
-	SED_CMD := sed -i ''
-else
-	SED_CMD := sed -i
-endif
-
 .PHONY: all
 all: clean build-pkg update-package-web remove-unused-files
 
@@ -26,7 +18,7 @@ build-pkg:
 
 .PHONY: update-package-web
 update-package-web:
-	$(SED_CMD) "s|import initWbg, { wbg_rayon_start_worker } from '../../../';|import initWbg, { wbg_rayon_start_worker } from '../../../shielder_wasm';|g" pkg/pkg-web-multithreaded/snippets/wasm-bindgen-rayon-3e04391371ad0a8e/src/workerHelpers.worker.js
+	./update-worker-helpers.sh
 
 .PHONY: remove-unused-files
 remove-unused-files:
@@ -36,3 +28,4 @@ remove-unused-files:
 .PHONY: test
 test:
 	cargo test --release
+

--- a/crates/shielder-wasm/update-worker-helpers.sh
+++ b/crates/shielder-wasm/update-worker-helpers.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# `sed -i` is used differently under MacOS
+OS=$(uname)
+if [ "$OS" = "Darwin" ]; then
+  SED_CMD="sed -i ''"
+else
+  SED_CMD="sed -i"
+fi
+
+# Path to the file we need to modify
+FILE="pkg/pkg-web-multithreaded/snippets/wasm-bindgen-rayon-3e04391371ad0a8e/src/workerHelpers.js"
+
+
+# First patch: Add import at the top
+# Create a temp file with the import line and append original content
+$SED_CMD '21i \
+import HelperWorker from "./workerHelpers.worker.js?worker&inline";
+' "$FILE"
+
+# Second patch: Replace worker creation code
+# Using awk for multi-line replacement since it's more reliable than sed
+awk '
+  BEGIN { p=1 }
+  /const worker = new Worker/ { 
+    print "      const worker = new HelperWorker();"
+    p=0 
+  }
+  /type: .module./ { p=0 }
+  p { print }
+  /\);/ { p=1 }
+' "$FILE" > temp_file
+mv temp_file "$FILE"
+
+# Third patch: Update import in worker file
+WORKER_FILE="pkg/pkg-web-multithreaded/snippets/wasm-bindgen-rayon-3e04391371ad0a8e/src/workerHelpers.worker.js"
+$SED_CMD "s|import initWbg, { wbg_rayon_start_worker } from '../../../';|import initWbg, { wbg_rayon_start_worker } from '../../../shielder_wasm';|g" "$WORKER_FILE"
+

--- a/crates/shielder_bindings/Makefile
+++ b/crates/shielder_bindings/Makefile
@@ -1,11 +1,3 @@
-# `sed -i` is used differently under MacOS
-OS := $(shell uname)
-ifeq ($(OS), Darwin)
-	SED_CMD := sed -i ''
-else
-	SED_CMD := sed -i
-endif
-
 .PHONY: help
 help: # Show help for each of the Makefile recipes.
 	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
@@ -33,7 +25,7 @@ build-pkg-wasm:
 
 .PHONY: update-package-web
 update-package-web:
-	$(SED_CMD) "s|import initWbg, { wbg_rayon_start_worker } from '../../../';|import initWbg, { wbg_rayon_start_worker } from '../../../shielder_bindings';|g" pkg/pkg-web-multithreaded/snippets/wasm-bindgen-rayon-3e04391371ad0a8e/src/workerHelpers.worker.js
+    ./update-worker-helpers.sh
 
 .PHONY: remove-unused-files-wasm
 remove-unused-files-wasm:

--- a/crates/shielder_bindings/update-worker-helpers.sh
+++ b/crates/shielder_bindings/update-worker-helpers.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# `sed -i` is used differently under MacOS
+OS=$(uname)
+if [ "$OS" = "Darwin" ]; then
+  SED_CMD="sed -i ''"
+else
+  SED_CMD="sed -i"
+fi
+
+# Path to the file we need to modify
+FILE="pkg/pkg-web-multithreaded/snippets/wasm-bindgen-rayon-3e04391371ad0a8e/src/workerHelpers.js"
+
+
+# First patch: Add import at the top
+# Create a temp file with the import line and append original content
+$SED_CMD '21i \
+import HelperWorker from "./workerHelpers.worker.js?worker&inline";
+' "$FILE"
+
+# Second patch: Replace worker creation code
+# Using awk for multi-line replacement since it's more reliable than sed
+awk '
+  BEGIN { p=1 }
+  /const worker = new Worker/ { 
+    print "      const worker = new HelperWorker();"
+    p=0 
+  }
+  /type: .module./ { p=0 }
+  p { print }
+  /\);/ { p=1 }
+' "$FILE" > temp_file
+mv temp_file "$FILE"
+
+# Third patch: Update import in worker file
+WORKER_FILE="pkg/pkg-web-multithreaded/snippets/wasm-bindgen-rayon-3e04391371ad0a8e/src/workerHelpers.worker.js"
+$SED_CMD "s|import initWbg, { wbg_rayon_start_worker } from '../../../';|import initWbg, { wbg_rayon_start_worker } from '../../../shielder_wasm';|g" "$WORKER_FILE"
+


### PR DESCRIPTION
Applying patches to wasm bindings for wxt-vite extensions.

Created patches both in `shielder-wasm` in `shielder_bindings` crates, as `shielder-wasm` is soon going to be deprecated, but tests should pass