### PR TITLE
ZK-1337: simplify directory layout & remove console logs

### DIFF
--- a/ts/shielder-sdk/__tests/actions/deposit.test.ts
+++ b/ts/shielder-sdk/__tests/actions/deposit.test.ts
@@ -8,15 +8,12 @@ import {
   scalarToBigint
 } from "@cardinal-cryptography/shielder-sdk-crypto";
 
-import { MockedCryptoClient, hashedNote } from "../../helpers";
+import { MockedCryptoClient, hashedNote } from "../helpers";
 
-import { DepositAction } from "../../../src/shielder/actions/deposit";
-import { AccountState } from "../../../src/shielder/state";
-import {
-  IContract,
-  VersionRejectedByContract
-} from "../../../src/chain/contract";
-import { SendShielderTransaction } from "../../../src/shielder/client";
+import { DepositAction } from "../../src/actions/deposit";
+import { AccountState } from "../../src/state";
+import { IContract, VersionRejectedByContract } from "../../src/chain/contract";
+import { SendShielderTransaction } from "../../src/client";
 
 const expectPubInputsCorrect = async (
   pubInputs: DepositPubInputs,

--- a/ts/shielder-sdk/__tests/actions/newAccount.test.ts
+++ b/ts/shielder-sdk/__tests/actions/newAccount.test.ts
@@ -8,15 +8,12 @@ import {
   scalarToBigint
 } from "@cardinal-cryptography/shielder-sdk-crypto";
 
-import { MockedCryptoClient, hashedNote } from "../../helpers";
+import { MockedCryptoClient, hashedNote } from "../helpers";
 
-import { NewAccountAction } from "../../../src/shielder/actions/newAccount";
-import { AccountState } from "../../../src/shielder/state";
-import {
-  IContract,
-  VersionRejectedByContract
-} from "../../../src/chain/contract";
-import { SendShielderTransaction } from "../../../src/shielder/client";
+import { NewAccountAction } from "../../src/actions/newAccount";
+import { AccountState } from "../../src/state";
+import { IContract, VersionRejectedByContract } from "../../src/chain/contract";
+import { SendShielderTransaction } from "../../src/client";
 
 const expectPubInputsCorrect = async (
   pubInputs: NewAccountPubInputs,

--- a/ts/shielder-sdk/__tests/actions/withdraw.test.ts
+++ b/ts/shielder-sdk/__tests/actions/withdraw.test.ts
@@ -8,16 +8,16 @@ import {
   WithdrawPubInputs
 } from "@cardinal-cryptography/shielder-sdk-crypto";
 
-import { MockedCryptoClient, hashedNote } from "../../helpers";
+import { MockedCryptoClient, hashedNote } from "../helpers";
 
-import { WithdrawAction } from "../../../src/shielder/actions/withdraw";
-import { AccountState } from "../../../src/shielder/state";
-import { IContract } from "../../../src/chain/contract";
+import { WithdrawAction } from "../../src/actions/withdraw";
+import { AccountState } from "../../src/state";
+import { IContract } from "../../src/chain/contract";
 import {
   IRelayer,
   VersionRejectedByRelayer,
   WithdrawResponse
-} from "../../../src/chain/relayer";
+} from "../../src/chain/relayer";
 import { encodePacked, hexToBigInt, keccak256 } from "viem";
 
 const expectPubInputsCorrect = async (

--- a/ts/shielder-sdk/src/actions/deposit.ts
+++ b/ts/shielder-sdk/src/actions/deposit.ts
@@ -6,10 +6,10 @@ import {
   Scalar,
   scalarToBigint
 } from "@cardinal-cryptography/shielder-sdk-crypto";
-import { SendShielderTransaction } from "@/shielder/client";
-import { Calldata } from "@/shielder/actions";
-import { INonceGenerator, NoteAction } from "@/shielder/actions/utils";
-import { AccountState } from "@/shielder/state";
+import { SendShielderTransaction } from "@/client";
+import { Calldata } from "@/actions";
+import { INonceGenerator, NoteAction } from "@/actions/utils";
+import { AccountState } from "@/state";
 
 export interface DepositCalldata extends Calldata {
   calldata: {
@@ -128,7 +128,6 @@ export class DepositAction extends NoteAction {
         trapdoorNew
       })
       .catch((e) => {
-        console.error(e);
         throw new Error(`Failed to prove deposit: ${e}`);
       });
     const pubInputs = await this.preparePubInputs(
@@ -190,7 +189,6 @@ export class DepositAction extends NoteAction {
       if (e instanceof VersionRejectedByContract) {
         throw e;
       }
-      console.error(e);
       throw new Error(`Failed to deposit: ${e}`);
     });
     return txHash;

--- a/ts/shielder-sdk/src/actions/index.ts
+++ b/ts/shielder-sdk/src/actions/index.ts
@@ -1,6 +1,7 @@
 import { NewAccountAction, NewAccountCalldata } from "./newAccount";
 import { DepositAction, DepositCalldata } from "./deposit";
 import { WithdrawAction, WithdrawCalldata } from "./withdraw";
+import { INonceGenerator } from "./utils";
 
 export interface Calldata {
   provingTimeMillis: number;
@@ -12,5 +13,6 @@ export {
   NewAccountAction,
   NewAccountCalldata,
   WithdrawAction,
-  WithdrawCalldata
+  WithdrawCalldata,
+  INonceGenerator
 };

--- a/ts/shielder-sdk/src/actions/newAccount.ts
+++ b/ts/shielder-sdk/src/actions/newAccount.ts
@@ -6,9 +6,9 @@ import {
   Scalar,
   scalarToBigint
 } from "@cardinal-cryptography/shielder-sdk-crypto";
-import { SendShielderTransaction } from "@/shielder/client";
-import { NoteAction } from "@/shielder/actions/utils";
-import { AccountState } from "@/shielder/state";
+import { SendShielderTransaction } from "@/client";
+import { NoteAction } from "@/actions/utils";
+import { AccountState } from "@/state";
 
 export interface NewAccountCalldata {
   calldata: {
@@ -83,7 +83,6 @@ export class NewAccountAction extends NoteAction {
         initialDeposit: Scalar.fromBigint(amount)
       })
       .catch((e) => {
-        console.error(e);
         throw new Error(`Failed to prove new account: ${e}`);
       });
     const pubInputs = await this.preparePubInputs(state, amount);
@@ -132,7 +131,6 @@ export class NewAccountAction extends NoteAction {
       to: this.contract.getAddress(),
       value: amount
     }).catch((e) => {
-      console.error(e);
       throw new Error(`Failed to create new account: ${e}`);
     });
     return txHash;

--- a/ts/shielder-sdk/src/actions/utils.ts
+++ b/ts/shielder-sdk/src/actions/utils.ts
@@ -2,7 +2,7 @@ import {
   CryptoClient,
   Scalar
 } from "@cardinal-cryptography/shielder-sdk-crypto";
-import { AccountState } from "@/shielder/state";
+import { AccountState } from "@/state";
 import { noteVersion } from "@/utils";
 
 export abstract class NoteAction {

--- a/ts/shielder-sdk/src/actions/withdraw.ts
+++ b/ts/shielder-sdk/src/actions/withdraw.ts
@@ -6,10 +6,10 @@ import {
   scalarToBigint,
   WithdrawPubInputs
 } from "@cardinal-cryptography/shielder-sdk-crypto";
-import { AccountState } from "@/shielder/state";
+import { AccountState } from "@/state";
 import { Address, encodePacked, hexToBigInt, keccak256 } from "viem";
 import { IRelayer, VersionRejectedByRelayer } from "@/chain/relayer";
-import { INonceGenerator, NoteAction } from "@/shielder/actions/utils";
+import { INonceGenerator, NoteAction } from "@/actions/utils";
 
 export interface WithdrawCalldata {
   expectedContractVersion: `0x${string}`;
@@ -189,7 +189,6 @@ export class WithdrawAction extends NoteAction {
         commitment
       })
       .catch((e) => {
-        console.error(e);
         throw new Error(`Failed to prove withdrawal: ${e}`);
       });
     const pubInputs = await this.preparePubInputs(
@@ -247,7 +246,6 @@ export class WithdrawAction extends NoteAction {
         if (e instanceof VersionRejectedByRelayer) {
           throw e;
         }
-        console.error(e);
         throw new Error(`Failed to withdraw: ${e}`);
       });
     return txHash as `0x${string}`;

--- a/ts/shielder-sdk/src/client.ts
+++ b/ts/shielder-sdk/src/client.ts
@@ -1,8 +1,5 @@
-import {
-  Contract,
-  IContract,
-  VersionRejectedByContract
-} from "@/chain/contract";
+import { CryptoClient } from "@cardinal-cryptography/shielder-sdk-crypto";
+import { CustomError } from "ts-custom-error";
 import {
   Address,
   createPublicClient,
@@ -11,26 +8,31 @@ import {
   http,
   PublicClient
 } from "viem";
-import { IRelayer, Relayer, VersionRejectedByRelayer } from "@/chain/relayer";
-import { ShielderTransaction, StateManager } from "@/shielder/state";
-import { NewAccountAction } from "@/shielder/actions/newAccount";
-import { DepositAction } from "@/shielder/actions/deposit";
-import { WithdrawAction } from "@/shielder/actions/withdraw";
+
 import {
-  StateSynchronizer,
-  UnexpectedVersionInEvent
-} from "@/shielder/state/sync";
+  Contract,
+  IContract,
+  VersionRejectedByContract
+} from "@/chain/contract";
+import { IRelayer, Relayer, VersionRejectedByRelayer } from "@/chain/relayer";
+import {
+  NewAccountAction,
+  DepositAction,
+  WithdrawAction,
+  INonceGenerator,
+  Calldata
+} from "@/actions";
+import { contractVersion } from "@/constants";
+import { idHidingNonce } from "@/utils";
 import {
   createStorage,
-  InjectedStorageInterface
-} from "@/shielder/state/storageSchema";
-import { Calldata } from "@/shielder/actions";
-import { contractVersion } from "@/constants";
-import { CustomError } from "ts-custom-error";
-import { CryptoClient } from "@cardinal-cryptography/shielder-sdk-crypto";
-import { StateEventsFilter } from "@/shielder/state/events";
-import { INonceGenerator } from "./actions/utils";
-import { idHidingNonce } from "@/utils";
+  InjectedStorageInterface,
+  ShielderTransaction,
+  StateEventsFilter,
+  StateManager,
+  StateSynchronizer,
+  UnexpectedVersionInEvent
+} from "@/state";
 
 export type ShielderOperation = "shield" | "withdraw" | "sync";
 

--- a/ts/shielder-sdk/src/index.ts
+++ b/ts/shielder-sdk/src/index.ts
@@ -2,7 +2,7 @@ export {
   createShielderClient,
   SendShielderTransaction,
   OutdatedSdkError
-} from "@/shielder/client";
-export { type AccountState, type ShielderTransaction } from "@/shielder/state";
-export { storageSchema, InjectedStorageInterface } from "@/shielder/state";
+} from "@/client";
+export { type AccountState, type ShielderTransaction } from "@/state";
+export { storageSchema, InjectedStorageInterface } from "@/state";
 export { shieldActionGasLimit } from "@/constants";

--- a/ts/shielder-sdk/src/state/events.ts
+++ b/ts/shielder-sdk/src/state/events.ts
@@ -1,7 +1,7 @@
-import { AccountState } from "@/shielder/state";
-import { DepositAction } from "@/shielder/actions/deposit";
-import { NewAccountAction } from "@/shielder/actions/newAccount";
-import { WithdrawAction } from "@/shielder/actions/withdraw";
+import { AccountState } from "@/state";
+import { DepositAction } from "@/actions/deposit";
+import { NewAccountAction } from "@/actions/newAccount";
+import { WithdrawAction } from "@/actions/withdraw";
 import { NoteEvent } from "@/chain/contract";
 import { scalarToBigint } from "@cardinal-cryptography/shielder-sdk-crypto";
 

--- a/ts/shielder-sdk/src/state/index.ts
+++ b/ts/shielder-sdk/src/state/index.ts
@@ -1,0 +1,20 @@
+import { StateManager } from "./manager";
+import { StateSynchronizer, UnexpectedVersionInEvent } from "./sync";
+import { StateEventsFilter } from "./events";
+import storageSchema, {
+  InjectedStorageInterface,
+  createStorage
+} from "./storageSchema";
+import { ShielderTransaction, AccountState } from "./types";
+
+export {
+  storageSchema,
+  createStorage,
+  AccountState,
+  InjectedStorageInterface,
+  ShielderTransaction,
+  StateManager,
+  StateSynchronizer,
+  StateEventsFilter,
+  UnexpectedVersionInEvent
+};

--- a/ts/shielder-sdk/src/state/manager.ts
+++ b/ts/shielder-sdk/src/state/manager.ts
@@ -4,58 +4,10 @@ import {
   scalarsEqual,
   scalarToBigint
 } from "@cardinal-cryptography/shielder-sdk-crypto";
-import { Address, Hex } from "viem";
-import storageSchema, {
-  InjectedStorageInterface,
-  StorageInterface
-} from "./storageSchema";
-import { NoteEvent } from "@/chain/contract";
+import { StorageInterface } from "./storageSchema";
+import { Hex } from "viem";
+import { AccountState } from "./types";
 import { storageSchemaVersion } from "@/constants";
-
-export type AccountState = {
-  /**
-   * Account id, a scalar derived from the private key.
-   */
-  id: Scalar;
-  /**
-   * Account nonce, increments for each new action.
-   */
-  nonce: bigint;
-  /**
-   * Account balance, in wei.
-   */
-  balance: bigint;
-  /**
-   * Hash of the last note.
-   */
-  currentNote: Scalar;
-  /**
-   * Merkle tree index of the last note.
-   */
-  currentNoteIndex?: bigint;
-  /**
-   * Version of the storage schema.
-   */
-  storageSchemaVersion: number;
-};
-
-export type ShielderTransaction = {
-  type: "NewAccountNative" | "DepositNative" | "WithdrawNative";
-  amount: bigint;
-  to?: Address;
-  txHash: Hex;
-  block: bigint;
-};
-
-export const eventToTransaction = (event: NoteEvent): ShielderTransaction => {
-  return {
-    type: event.name,
-    amount: event.amount,
-    to: event.to,
-    txHash: event.txHash,
-    block: event.block
-  };
-};
 
 export class StateManager {
   private storage: StorageInterface;
@@ -155,5 +107,3 @@ const emptyAccountState = (id: Scalar): AccountState => {
     storageSchemaVersion
   };
 };
-
-export { storageSchema, InjectedStorageInterface, emptyAccountState };

--- a/ts/shielder-sdk/src/state/storageSchema.ts
+++ b/ts/shielder-sdk/src/state/storageSchema.ts
@@ -54,8 +54,7 @@ const createStorage = (
     try {
       return storageSchema[key].parse(JSON.parse(storedValue));
     } catch (error) {
-      console.error(`Failed to parse storage value for key ${key}:`, error);
-      return null;
+      throw new Error(`Failed to parse storage value for key ${key}: ${error}`);
     }
   };
   const setItem = async <K extends StateManagerStorageKeys>(

--- a/ts/shielder-sdk/src/state/storageSchema.ts
+++ b/ts/shielder-sdk/src/state/storageSchema.ts
@@ -54,7 +54,9 @@ const createStorage = (
     try {
       return storageSchema[key].parse(JSON.parse(storedValue));
     } catch (error) {
-      throw new Error(`Failed to parse storage value for key ${key}: ${error}`);
+      throw new Error(
+        `Failed to parse storage value for key ${key}: ${(error as Error).message}`
+      );
     }
   };
   const setItem = async <K extends StateManagerStorageKeys>(

--- a/ts/shielder-sdk/src/state/sync.ts
+++ b/ts/shielder-sdk/src/state/sync.ts
@@ -1,18 +1,14 @@
 import { CustomError } from "ts-custom-error";
-import { IContract } from "@/chain/contract";
+import { IContract, NoteEvent } from "@/chain/contract";
 import {
   CryptoClient,
   scalarToBigint
 } from "@cardinal-cryptography/shielder-sdk-crypto";
-import {
-  AccountState,
-  eventToTransaction,
-  ShielderTransaction,
-  StateManager
-} from "@/shielder/state";
-import { StateEventsFilter } from "@/shielder/state/events";
+import { StateEventsFilter } from "@/state/events";
 import { Mutex } from "async-mutex";
 import { isVersionSupported } from "@/utils";
+import { StateManager } from "./manager";
+import { AccountState, ShielderTransaction } from "./types";
 
 export class UnexpectedVersionInEvent extends CustomError {
   public constructor(message: string) {
@@ -111,7 +107,6 @@ export class StateSynchronizer {
     );
 
     if (events.length != 1) {
-      console.error(events);
       throw new Error(
         `Unexpected number of events: ${events.length}, expected 1 event`
       );
@@ -146,3 +141,13 @@ export class StateSynchronizer {
     return event;
   }
 }
+
+const eventToTransaction = (event: NoteEvent): ShielderTransaction => {
+  return {
+    type: event.name,
+    amount: event.amount,
+    to: event.to,
+    txHash: event.txHash,
+    block: event.block
+  };
+};

--- a/ts/shielder-sdk/src/state/types.ts
+++ b/ts/shielder-sdk/src/state/types.ts
@@ -1,0 +1,37 @@
+import { Scalar } from "@cardinal-cryptography/shielder-sdk-crypto";
+import { Address, Hex } from "viem";
+
+export type AccountState = {
+  /**
+   * Account id, a scalar derived from the private key.
+   */
+  id: Scalar;
+  /**
+   * Account nonce, increments for each new action.
+   */
+  nonce: bigint;
+  /**
+   * Account balance, in wei.
+   */
+  balance: bigint;
+  /**
+   * Hash of the last note.
+   */
+  currentNote: Scalar;
+  /**
+   * Merkle tree index of the last note.
+   */
+  currentNoteIndex?: bigint;
+  /**
+   * Version of the storage schema.
+   */
+  storageSchemaVersion: number;
+};
+
+export type ShielderTransaction = {
+  type: "NewAccountNative" | "DepositNative" | "WithdrawNative";
+  amount: bigint;
+  to?: Address;
+  txHash: Hex;
+  block: bigint;
+};


### PR DESCRIPTION
- remove `./shielder` folder, as everything is in "shielder" domain
- add `index.ts` to every folder module, and list exports in it instead of exports in separate files.
- remove `console.error` logs, as we throw exceptions instead.