### PR TITLE
Relayer: permissible ERC20 tokens

### DIFF
--- a/crates/shielder-cli/src/shielder_ops/withdraw.rs
+++ b/crates/shielder-cli/src/shielder_ops/withdraw.rs
@@ -11,7 +11,7 @@ use shielder_account::{
 use shielder_contract::{
     events::get_event, merkle_path::get_current_merkle_path, ShielderContract::WithdrawNative,
 };
-use shielder_relayer::{QuoteFeeResponse, RelayQuery, RelayResponse};
+use shielder_relayer::{FeeToken, QuoteFeeResponse, RelayQuery, RelayResponse};
 use shielder_setup::version::contract_version;
 use tokio::time::sleep;
 use tracing::{debug, info};
@@ -147,5 +147,6 @@ async fn prepare_relayer_query(
         nullifier_hash: calldata.oldNullifierHash,
         new_note: calldata.newNote,
         proof: calldata.proof,
+        fee_token: FeeToken::Native,
     })
 }

--- a/crates/shielder-relayer/src/config/cli.rs
+++ b/crates/shielder-relayer/src/config/cli.rs
@@ -144,7 +144,8 @@ pub struct CLIConfig {
     #[clap(
         long,
         help = "Addresses of the ERC20 tokens that are qualified as a fee token.",
-        long_help = "Addresses of the ERC20 tokens that are qualified as a fee token."
+        long_help = "Addresses of the ERC20 tokens that are qualified as a fee token. If not provided, the value from the \
+            environment variable `{FEE_TOKEN_ENV}` will be used. If that is not set, assumed to be empty."
     )]
-    pub fee_tokens: Vec<String>,
+    pub fee_tokens: Option<Vec<String>>,
 }

--- a/crates/shielder-relayer/src/config/cli.rs
+++ b/crates/shielder-relayer/src/config/cli.rs
@@ -140,4 +140,11 @@ pub struct CLIConfig {
             the default value is `{DEFAULT_RELAY_GAS:?}`.")
     )]
     pub relay_gas: Option<u64>,
+
+    #[clap(
+        long,
+        help = "Addresses of the ERC20 tokens that are qualified as a fee token.",
+        long_help = "Addresses of the ERC20 tokens that are qualified as a fee token."
+    )]
+    pub fee_tokens: Vec<String>,
 }

--- a/crates/shielder-relayer/src/config/cli.rs
+++ b/crates/shielder-relayer/src/config/cli.rs
@@ -143,9 +143,10 @@ pub struct CLIConfig {
 
     #[clap(
         long,
-        help = "Addresses of the ERC20 tokens that are qualified as a fee token.",
-        long_help = "Addresses of the ERC20 tokens that are qualified as a fee token. If not provided, the value from the \
-            environment variable `{FEE_TOKEN_ENV}` will be used. If that is not set, assumed to be empty."
+        help = "Addresses of the ERC20 tokens (comma separated) that are qualified as a fee token.",
+        long_help = "Addresses of the ERC20 tokens (comma separated) that are qualified as a fee token. \
+            If not provided, the value from the environment variable `{FEE_TOKEN_ENV}` will be used. \
+            If that is not set, assumed to be empty."
     )]
     pub fee_tokens: Option<Vec<String>>,
 }

--- a/crates/shielder-relayer/src/config/mod.rs
+++ b/crates/shielder-relayer/src/config/mod.rs
@@ -52,12 +52,13 @@ pub struct ChainConfig {
     pub relay_gas: u64,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct OperationalConfig {
     pub balance_monitor_interval_secs: u64,
     pub nonce_policy: NoncePolicy,
     pub dry_running: DryRunning,
     pub relay_count_for_recharge: u32,
+    pub fee_tokens: Vec<Address>,
 }
 
 /// Resolved configuration for the Shielder relayer. Order of precedence is:
@@ -96,6 +97,7 @@ fn resolve_config_from_cli_config(
         relay_count_for_recharge,
         total_fee,
         relay_gas,
+        fee_tokens,
     }: CLIConfig,
 ) -> ServerConfig {
     let to_address = |s: &str| Address::from_str(s).expect("Invalid address");
@@ -149,6 +151,7 @@ fn resolve_config_from_cli_config(
             RELAY_COUNT_FOR_RECHARGE_ENV,
             Some(DEFAULT_RELAY_COUNT_FOR_RECHARGE),
         ),
+        fee_tokens: fee_tokens.iter().map(|a| to_address(a)).collect(),
     };
 
     ServerConfig {

--- a/crates/shielder-relayer/src/config/mod.rs
+++ b/crates/shielder-relayer/src/config/mod.rs
@@ -9,7 +9,7 @@ use defaults::{
 pub use enums::{DryRunning, LoggingFormat, NoncePolicy};
 use shielder_contract::alloy_primitives::{Address, U256};
 use shielder_relayer::{
-    BALANCE_MONITOR_INTERVAL_SECS_ENV, DRY_RUNNING_ENV, FEE_DESTINATION_KEY_ENV,
+    BALANCE_MONITOR_INTERVAL_SECS_ENV, DRY_RUNNING_ENV, FEE_DESTINATION_KEY_ENV, FEE_TOKENS_ENV,
     LOGGING_FORMAT_ENV, NODE_RPC_URL_ENV, NONCE_POLICY_ENV, RELAYER_HOST_ENV,
     RELAYER_METRICS_PORT_ENV, RELAYER_PORT_ENV, RELAYER_SIGNING_KEYS_ENV,
     RELAY_COUNT_FOR_RECHARGE_ENV, RELAY_GAS_ENV, SHIELDER_CONTRACT_ADDRESS_ENV, TOTAL_FEE_ENV,
@@ -138,6 +138,16 @@ fn resolve_config_from_cli_config(
         relay_gas: resolve_value(relay_gas, RELAY_GAS_ENV, Some(DEFAULT_RELAY_GAS)),
     };
 
+    let fee_tokens = fee_tokens
+        .unwrap_or_else(|| {
+            std::env::var(FEE_TOKENS_ENV)
+                .map(|env| env.split(',').map(|s| s.to_string()).collect())
+                .unwrap_or_default()
+        })
+        .iter()
+        .map(|a| to_address(a))
+        .collect();
+
     let operational_config = OperationalConfig {
         balance_monitor_interval_secs: resolve_value(
             balance_monitor_interval_secs,
@@ -151,7 +161,7 @@ fn resolve_config_from_cli_config(
             RELAY_COUNT_FOR_RECHARGE_ENV,
             Some(DEFAULT_RELAY_COUNT_FOR_RECHARGE),
         ),
-        fee_tokens: fee_tokens.iter().map(|a| to_address(a)).collect(),
+        fee_tokens,
     };
 
     ServerConfig {

--- a/crates/shielder-relayer/src/config/tests.rs
+++ b/crates/shielder-relayer/src/config/tests.rs
@@ -27,6 +27,7 @@ fn config_resolution() {
     let relay_count_for_recharge = DEFAULT_RELAY_COUNT_FOR_RECHARGE;
     let total_fee = DEFAULT_TOTAL_FEE.to_string();
     let relay_gas: u64 = DEFAULT_RELAY_GAS + 1;
+    let fee_tokens = vec![address!("1111111111111111111111111111111111111111")];
 
     let expected_config = ServerConfig {
         logging_format, // from CLI
@@ -48,6 +49,7 @@ fn config_resolution() {
             nonce_policy,                  // default
             dry_running,                   // from CLI
             relay_count_for_recharge,      // default
+            fee_tokens,                    // from CLI
         },
     };
 
@@ -67,6 +69,7 @@ fn config_resolution() {
         relay_count_for_recharge: None,
         total_fee: Some(total_fee),
         relay_gas: None,
+        fee_tokens: vec!["1111111111111111111111111111111111111111".to_string()],
     };
 
     // ---- Environment variables. -----------------------------------------------------------

--- a/crates/shielder-relayer/src/config/tests.rs
+++ b/crates/shielder-relayer/src/config/tests.rs
@@ -49,7 +49,7 @@ fn config_resolution() {
             nonce_policy,                  // default
             dry_running,                   // from CLI
             relay_count_for_recharge,      // default
-            fee_tokens,                    // from CLI
+            fee_tokens,                    // from env
         },
     };
 
@@ -69,7 +69,7 @@ fn config_resolution() {
         relay_count_for_recharge: None,
         total_fee: Some(total_fee),
         relay_gas: None,
-        fee_tokens: vec!["1111111111111111111111111111111111111111".to_string()],
+        fee_tokens: None,
     };
 
     // ---- Environment variables. -----------------------------------------------------------
@@ -82,6 +82,7 @@ fn config_resolution() {
         std::env::set_var(FEE_DESTINATION_KEY_ENV, fee_destination_key);
         std::env::set_var(RELAYER_SIGNING_KEYS_ENV, format!("{key1},{key2}"));
         std::env::set_var(RELAY_GAS_ENV, relay_gas.to_string());
+        std::env::set_var(FEE_TOKENS_ENV, "1111111111111111111111111111111111111111");
     }
 
     // ---- Test. ------------------------------------------------------------------------------

--- a/crates/shielder-relayer/src/lib.rs
+++ b/crates/shielder-relayer/src/lib.rs
@@ -20,6 +20,7 @@ pub const DRY_RUNNING_ENV: &str = "DRY_RUNNING";
 pub const RELAY_COUNT_FOR_RECHARGE_ENV: &str = "RELAY_COUNT_FOR_RECHARGE";
 pub const TOTAL_FEE_ENV: &str = "TOTAL_FEE";
 pub const RELAY_GAS_ENV: &str = "RELAY_GAS";
+pub const FEE_TOKENS_ENV: &str = "FEE_TOKENS";
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]

--- a/crates/shielder-relayer/src/lib.rs
+++ b/crates/shielder-relayer/src/lib.rs
@@ -77,6 +77,13 @@ pub struct RelayQuery {
     pub nullifier_hash: U256,
     pub new_note: U256,
     pub proof: Bytes,
+    pub fee_token: FeeToken,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum FeeToken {
+    Native,
+    ERC20(Address),
 }
 
 pub fn server_error(msg: &str) -> Response {

--- a/crates/shielder-relayer/src/main.rs
+++ b/crates/shielder-relayer/src/main.rs
@@ -43,6 +43,7 @@ pub struct AppState {
     pub signer_addresses: Vec<Address>,
     pub taskmaster: Taskmaster,
     pub balances: Balances,
+    pub fee_tokens: Vec<Address>,
 }
 
 struct Signers {
@@ -136,6 +137,7 @@ async fn start_main_server(config: &ServerConfig, signers: Signers) -> Result<()
             config.operations.dry_running,
             report_for_recharge,
         ),
+        fee_tokens: config.operations.fee_tokens.clone(),
     };
 
     let app = Router::new()

--- a/crates/shielder-relayer/src/relay/request_trace.rs
+++ b/crates/shielder-relayer/src/relay/request_trace.rs
@@ -73,6 +73,12 @@ impl RequestTrace {
         self.finish("❌ VERSION FAILURE");
     }
 
+    pub fn record_incorrect_token_fee(&mut self, requested_token: &Address) {
+        metrics::counter!(WITHDRAW_FAILURE).increment(1);
+        error!("Requested token fee is not supported: {requested_token}");
+        self.finish("❌ FEE TOKEN FAILURE");
+    }
+
     pub fn record_failure(&mut self, err: ShielderContractError) {
         metrics::counter!(WITHDRAW_FAILURE).increment(1);
         error!("Relay failed: {err}");

--- a/crates/shielder-relayer/tests/utils/mod.rs
+++ b/crates/shielder-relayer/tests/utils/mod.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{Address, Bytes, U256};
 use rand::Rng;
 use reqwest::Response;
 use serde::{Deserialize, Serialize};
-use shielder_relayer::RelayQuery;
+use shielder_relayer::{FeeToken, RelayQuery};
 use shielder_setup::version::contract_version;
 use testcontainers::{
     core::IntoContainerPort, runners::AsyncRunner, ContainerAsync, ContainerRequest, Image,
@@ -72,6 +72,7 @@ impl TestContext {
                 nullifier_hash: U256::ZERO,
                 new_note: U256::ZERO,
                 proof: Bytes::new(),
+                fee_token: FeeToken::Native,
             })
             .send()
             .await

--- a/crates/stress-testing/src/party.rs
+++ b/crates/stress-testing/src/party.rs
@@ -8,7 +8,7 @@ use shielder_circuits::{
     withdraw::WithdrawCircuit,
 };
 use shielder_contract::{alloy_primitives::U256, merkle_path::get_current_merkle_path};
-use shielder_relayer::{QuoteFeeResponse, RelayQuery};
+use shielder_relayer::{FeeToken, QuoteFeeResponse, RelayQuery};
 use shielder_setup::version::contract_version;
 
 use crate::{actor::Actor, config::Config, util::proving_keys, WITHDRAW_AMOUNT};
@@ -127,6 +127,7 @@ async fn prepare_relay_query(
         nullifier_hash: calldata.oldNullifierHash,
         new_note: calldata.newNote,
         proof: calldata.proof,
+        fee_token: FeeToken::Native,
     };
     println!("  ✅ Prepared relay query for actor {}", actor.id);
     Ok(query)


### PR DESCRIPTION
1. Add a configuration parameter to specify which ERC20 tokens are supported as payment tokens.
2. Add a parameter to the `RelayQuery` and validate it.