### PR TITLE
ZK-714: Adapt contract tests to ERC20

### DIFF
--- a/LICENSE-MIT-OpenZeppelin
+++ b/LICENSE-MIT-OpenZeppelin
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2016-2025 Zeppelin Group Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,12 @@
 NOTICE
 
+## shielder-circuits  
+
 This project depends on `shielder-circuits`, which is licensed under GPL-3.0-only with Classpath exception.
 The full text of this license is available in LICENSE-GPL-3.0-only-with-Classpath-exception.
+
+## openzeppelin-contracts  
+
+This project includes components from `openzeppelin-contracts`, licensed under the MIT license. The original license text is included in `LICENSE-MIT-OpenZeppelin`
+
+Source: https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/contracts/FakeERC20Token.sol
+++ b/contracts/FakeERC20Token.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.26;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * Fake token for testing purposes.
+ */
+contract FakeERC20Token is ERC20 {
+    error DestinationTriggeredRevert();
+
+    constructor() ERC20("FakeERC20Token", "FAKE") {
+        _mint(msg.sender, type(uint256).max);
+    }
+
+    function _update(
+        address from,
+        address to,
+        uint256 value
+    ) internal override {
+        if (to == 0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF) {
+            revert DestinationTriggeredRevert();
+        }
+        super._update(from, to, value);
+    }
+}

--- a/contracts/Shielder.sol
+++ b/contracts/Shielder.sol
@@ -356,8 +356,12 @@ contract Shielder is
             if (!success) revert NativeTransferFailed();
         } else {
             IERC20 token = IERC20(tokenAddress);
-            bool transferSuccess = token.transfer(to, amount);
-            if (!transferSuccess) revert ERC20TransferFailed();
+
+            try token.transfer(to, amount) returns (bool transferSuccess) {
+                if (!transferSuccess) revert ERC20TransferFailed();
+            } catch {
+                revert ERC20TransferFailed();
+            }
         }
     }
 }

--- a/crates/evm-utils/src/evm_runner.rs
+++ b/crates/evm-utils/src/evm_runner.rs
@@ -4,7 +4,7 @@ use revm::{
     primitives::{address, Address, EVMError, ExecutionResult, Output, TxKind, U256},
     Evm, InMemoryDB,
 };
-use revm_primitives::{AccountInfo, Bytecode, Bytes, Log};
+use revm_primitives::{AccountInfo, Bytecode, Bytes, Log, TxEnv};
 use thiserror::Error;
 
 use crate::{compilation::source_to_bytecode, repo_root_dir};
@@ -124,18 +124,46 @@ impl EvmRunner {
     ) -> Result<SuccessResult, EvmRunnerError> {
         let mut evm = Evm::builder()
             .with_db(&mut self.db)
-            .modify_tx_env(|tx| {
-                tx.caller = caller.unwrap_or(address!("0000000000000000000000000000000000000000"));
-                tx.gas_limit = u64::MAX;
-                tx.transact_to = TxKind::Call(address);
-                tx.data = calldata.into();
-                tx.value = U256::from(value.unwrap_or(U256::ZERO));
-                tx.chain_id = Some(1);
-            })
+            .modify_tx_env(|tx| Self::set_tx_env_for_call(address, calldata, caller, value, tx))
             .build();
 
-        let result = evm.transact_commit()?;
+        Self::handle_call_result(evm.transact_commit()?)
+    }
 
+    /// Apply `call` transaction to given `address` with `calldata`, but do not commit changes
+    /// to db. Return a tuple of `gas_used` and `return_data`.
+    pub fn call_ref(
+        &self,
+        address: Address,
+        calldata: Vec<u8>,
+        caller: Option<Address>,
+        value: Option<U256>,
+    ) -> Result<SuccessResult, EvmRunnerError> {
+        let mut evm = Evm::builder()
+            .with_ref_db(&self.db)
+            .modify_tx_env(|tx| Self::set_tx_env_for_call(address, calldata, caller, value, tx))
+            .build();
+
+        let result = evm.transact()?.result;
+        Self::handle_call_result(result)
+    }
+
+    fn set_tx_env_for_call(
+        address: Address,
+        calldata: Vec<u8>,
+        caller: Option<Address>,
+        value: Option<U256>,
+        tx: &mut TxEnv,
+    ) {
+        tx.caller = caller.unwrap_or(address!("0000000000000000000000000000000000000000"));
+        tx.gas_limit = u64::MAX;
+        tx.transact_to = TxKind::Call(address);
+        tx.data = calldata.into();
+        tx.value = U256::from(value.unwrap_or(U256::ZERO));
+        tx.chain_id = Some(1);
+    }
+
+    fn handle_call_result(result: ExecutionResult) -> Result<SuccessResult, EvmRunnerError> {
         match result {
             ExecutionResult::Success {
                 output,

--- a/crates/integration-tests/src/bin/gas_consumption.rs
+++ b/crates/integration-tests/src/bin/gas_consumption.rs
@@ -16,7 +16,7 @@ use integration_tests::{
         },
     },
     deploy::{deployment, Deployment},
-    deposit_proving_params, new_account_proving_params, withdraw_proving_params,
+    deposit_proving_params, new_account_proving_params, withdraw_proving_params, TestToken,
 };
 use shielder_account::ShielderAccount;
 use shielder_contract::ShielderContract::{depositCall, newAccountCall, withdrawCall};
@@ -54,6 +54,7 @@ fn main() {
     let calldata = Calldata::NewAccount(new_account_native_calldata(
         &mut deployment,
         &mut shielder_account,
+        TestToken::Native,
         amount,
     ));
 
@@ -63,7 +64,13 @@ fn main() {
     content.extend(&mut format!("{}: {gas_used}\n", &calldata).as_bytes().iter());
 
     let calldata = Calldata::Deposit(
-        deposit_native_calldata(&mut deployment, &mut shielder_account, amount).0,
+        deposit_native_calldata(
+            &mut deployment,
+            &mut shielder_account,
+            TestToken::Native,
+            amount,
+        )
+        .0,
     );
 
     let gas_used = measure_gas(&calldata, &mut deployment, &mut shielder_account);
@@ -74,6 +81,7 @@ fn main() {
         withdraw_native_calldata(
             &mut deployment,
             &mut shielder_account,
+            TestToken::Native,
             prepare_args(amount, U256::from(1)),
         )
         .0,
@@ -93,16 +101,28 @@ fn measure_gas(
 ) -> u64 {
     match calldata {
         Calldata::NewAccount(calldata) => {
-            new_account_native_call(deployment, shielder_account, U256::from(10), calldata)
-                .unwrap()
-                .1
-                .gas_used
+            new_account_native_call(
+                deployment,
+                shielder_account,
+                TestToken::Native,
+                U256::from(10),
+                calldata,
+            )
+            .unwrap()
+            .1
+            .gas_used
         }
         Calldata::Deposit(calldata) => {
-            deposit_native_call(deployment, shielder_account, U256::from(10), calldata)
-                .unwrap()
-                .1
-                .gas_used
+            deposit_native_call(
+                deployment,
+                shielder_account,
+                TestToken::Native,
+                U256::from(10),
+                calldata,
+            )
+            .unwrap()
+            .1
+            .gas_used
         }
         Calldata::Withdraw(calldata) => {
             withdraw_native_call(deployment, shielder_account, calldata)

--- a/crates/integration-tests/src/lib.rs
+++ b/crates/integration-tests/src/lib.rs
@@ -27,8 +27,18 @@ fn read_contract(contract_name: &str) -> String {
 }
 
 fn deploy_contract(contract_filename: &str, contract_name: &str, evm: &mut EvmRunner) -> Address {
+    deploy_contract_with_caller(contract_filename, contract_name, None, evm)
+}
+
+// Allows to deploy a contract while specifying the address that performs the deployment.
+fn deploy_contract_with_caller(
+    contract_filename: &str,
+    contract_name: &str,
+    caller: Option<Address>,
+    evm: &mut EvmRunner,
+) -> Address {
     let solidity_code = read_contract(contract_filename);
     let compiled_bytecode = source_to_bytecode(solidity_code, contract_name, true);
-    evm.create(compiled_bytecode, None)
+    evm.create(compiled_bytecode, caller)
         .unwrap_or_else(|_| panic!("Failed to deploy {contract_name} contract"))
 }

--- a/crates/integration-tests/src/shielder/calls/deposit_native.rs
+++ b/crates/integration-tests/src/shielder/calls/deposit_native.rs
@@ -1,21 +1,25 @@
-use alloy_primitives::{TxHash, U256};
+// TODO: Rename to `deposit.rs` since no longer testing just native.
+use std::str::FromStr;
+
+use alloy_primitives::{Address, TxHash, U256};
 use shielder_account::{
     call_data::{DepositCallType, MerkleProof},
     ShielderAccount,
 };
 use shielder_contract::ShielderContract::depositCall;
 
-use crate::shielder::{
-    deploy::Deployment, invoke_shielder_call, merkle::get_merkle_args, CallResult,
+use crate::{
+    deploy::ACTOR_ADDRESS,
+    shielder::{deploy::Deployment, invoke_shielder_call, merkle::get_merkle_args, CallResult},
+    TestToken,
 };
 pub fn prepare_call(
     deployment: &mut Deployment,
-    shielder_account: &mut ShielderAccount,
+    account: &mut ShielderAccount,
+    token: TestToken,
     amount: U256,
 ) -> (depositCall, U256) {
-    let note_index = shielder_account
-        .current_leaf_index()
-        .expect("No leaf index");
+    let note_index = account.current_leaf_index().expect("No leaf index");
 
     let (params, pk) = deployment.deposit_proving_params.clone();
     let (merkle_root, merkle_path) = get_merkle_args(
@@ -23,7 +27,7 @@ pub fn prepare_call(
         note_index,
         &mut deployment.evm,
     );
-    let calldata = shielder_account.prepare_call::<DepositCallType>(
+    let mut calldata = account.prepare_call::<DepositCallType>(
         &params,
         &pk,
         amount,
@@ -32,22 +36,42 @@ pub fn prepare_call(
             path: merkle_path,
         },
     );
+    calldata.tokenAddress = token.address(deployment);
     (calldata, note_index)
 }
 
+// Invokes the `deposit` call of the Shielder contract. Precedes the call with an appropriate
+// token approval if applicable.
 pub fn invoke_call(
     deployment: &mut Deployment,
-    shielder_account: &mut ShielderAccount,
+    account: &mut ShielderAccount,
+    token: TestToken,
     amount: U256,
     calldata: &depositCall,
 ) -> CallResult {
-    let call_result = invoke_shielder_call(deployment, calldata, Some(amount));
+    let call_value = match token {
+        TestToken::Native => Some(amount),
+        TestToken::FakeERC20 => {
+            deployment
+                .fake_token
+                .approve(
+                    &mut deployment.evm,
+                    Address::from_str(ACTOR_ADDRESS).unwrap(),
+                    deployment.contract_suite.shielder,
+                    amount,
+                )
+                .unwrap();
+            None
+        }
+    };
+
+    let call_result = invoke_shielder_call(deployment, calldata, call_value);
 
     match call_result {
         Ok((events, _success_result)) => {
             assert!(events.len() == 1);
             let event = events[0].clone();
-            shielder_account.register_action((TxHash::default(), event.clone()));
+            account.register_action((TxHash::default(), event.clone()));
             Ok((events, _success_result))
         }
         Err(err) => Err(err),
@@ -59,7 +83,7 @@ mod tests {
 
     use std::{assert_matches::assert_matches, mem, str::FromStr};
 
-    use alloy_primitives::{Address, Bytes, FixedBytes, U256};
+    use alloy_primitives::{Bytes, FixedBytes, U256};
     use evm_utils::SuccessResult;
     use halo2_proofs::halo2curves::ff::PrimeField;
     use rstest::rstest;
@@ -77,24 +101,28 @@ mod tests {
             calls::new_account_native,
             deploy::{deployment, Deployment},
             limits::{get_deposit_limit, set_deposit_limit},
+            TestToken,
         },
     };
 
     const GAS_CONSUMPTION: u64 = 1827769;
 
     #[rstest]
-    fn gas_consumption_regression(mut deployment: Deployment) {
-        let mut shielder_account = new_account_native::create_account_and_call(
+    #[case::native(TestToken::Native)]
+    #[case::erc20(TestToken::FakeERC20)]
+    fn gas_consumption_regression(mut deployment: Deployment, #[case] token: TestToken) {
+        let mut account = new_account_native::create_account_and_call(
             &mut deployment,
+            token,
             U256::from(1),
             U256::from(10),
         )
         .unwrap();
 
         let amount = U256::from(5);
-        let (calldata, _) = prepare_call(&mut deployment, &mut shielder_account, amount);
+        let (calldata, _) = prepare_call(&mut deployment, &mut account, token, amount);
         let (_, SuccessResult { gas_used, .. }) =
-            invoke_call(&mut deployment, &mut shielder_account, amount, &calldata).unwrap();
+            invoke_call(&mut deployment, &mut account, token, amount, &calldata).unwrap();
 
         assert!(
         gas_used < 110 * GAS_CONSUMPTION / 100,
@@ -103,17 +131,20 @@ mod tests {
     }
 
     #[rstest]
-    fn succeeds(mut deployment: Deployment) {
-        let mut shielder_account = new_account_native::create_account_and_call(
+    #[case::native(TestToken::Native)]
+    #[case::erc20(TestToken::FakeERC20)]
+    fn succeeds(mut deployment: Deployment, #[case] token: TestToken) {
+        let mut account = new_account_native::create_account_and_call(
             &mut deployment,
+            token,
             U256::from(1),
             U256::from(10),
         )
         .unwrap();
 
         let amount = U256::from(5);
-        let (calldata, note_index) = prepare_call(&mut deployment, &mut shielder_account, amount);
-        let events = invoke_call(&mut deployment, &mut shielder_account, amount, &calldata)
+        let (calldata, note_index) = prepare_call(&mut deployment, &mut account, token, amount);
+        let events = invoke_call(&mut deployment, &mut account, token, amount, &calldata)
             .unwrap()
             .0;
 
@@ -122,28 +153,37 @@ mod tests {
             vec![ShielderContractEvents::Deposit(Deposit {
                 contractVersion: FixedBytes([0, 1, 0]),
                 idHiding: calldata.idHiding,
-                tokenAddress: Address::ZERO,
+                tokenAddress: token.address(&deployment),
                 amount: U256::from(amount),
                 newNote: calldata.newNote,
                 newNoteIndex: note_index.saturating_add(U256::from(1)),
             })]
         );
-        assert!(actor_balance_decreased_by(&deployment, U256::from(15)));
-        assert_eq!(shielder_account.shielded_amount, U256::from(15))
+        assert!(actor_balance_decreased_by(
+            &deployment,
+            token,
+            U256::from(15)
+        ));
+        assert_eq!(account.shielded_amount, U256::from(15))
     }
+
     #[rstest]
-    fn fails_if_incorrect_expected_version(mut deployment: Deployment) {
-        let mut shielder_account = new_account_native::create_account_and_call(
+    #[case::native(TestToken::Native)]
+    #[case::erc20(TestToken::FakeERC20)]
+    fn fails_if_incorrect_expected_version(mut deployment: Deployment, #[case] token: TestToken) {
+        let mut account = new_account_native::create_account_and_call(
             &mut deployment,
+            token,
             U256::from(1),
             U256::from(10),
         )
         .unwrap();
-        let (mut calldata, _) = prepare_call(&mut deployment, &mut shielder_account, U256::ZERO);
+        let (mut calldata, _) = prepare_call(&mut deployment, &mut account, token, U256::ZERO);
         calldata.expectedContractVersion = FixedBytes([9, 8, 7]);
         let result = invoke_call(
             &mut deployment,
-            &mut shielder_account,
+            &mut account,
+            token,
             U256::from(5),
             &calldata,
         );
@@ -157,41 +197,58 @@ mod tests {
                 }
             ))
         );
-        assert!(actor_balance_decreased_by(&deployment, U256::from(10)))
+        assert!(actor_balance_decreased_by(
+            &deployment,
+            token,
+            U256::from(10)
+        ))
     }
 
     #[rstest]
-    fn can_consume_entire_contract_balance_limit(mut deployment: Deployment) {
-        let mut shielder_account = new_account_native::create_account_and_call(
+    #[case::native(TestToken::Native)]
+    #[case::erc20(TestToken::FakeERC20)]
+    fn can_consume_entire_contract_balance_limit(
+        mut deployment: Deployment,
+        #[case] token: TestToken,
+    ) {
+        let mut account = new_account_native::create_account_and_call(
             &mut deployment,
+            token,
             U256::from(1),
             U256::from((1u128 << 112) - 2),
         )
         .unwrap();
 
         let amount = U256::from(1);
-        let (calldata, _) = prepare_call(&mut deployment, &mut shielder_account, amount);
-        let result = invoke_call(&mut deployment, &mut shielder_account, amount, &calldata);
+        let (calldata, _) = prepare_call(&mut deployment, &mut account, token, amount);
+        let result = invoke_call(&mut deployment, &mut account, token, amount, &calldata);
 
         assert!(result.is_ok());
         assert!(actor_balance_decreased_by(
             &deployment,
+            token,
             U256::from((1u128 << 112) - 1)
         ))
     }
 
     #[rstest]
-    fn fails_if_contract_balance_limit_reached(mut deployment: Deployment) {
-        let mut shielder_account = new_account_native::create_account_and_call(
+    #[case::native(TestToken::Native)]
+    #[case::erc20(TestToken::FakeERC20)]
+    fn fails_if_contract_balance_limit_reached(
+        mut deployment: Deployment,
+        #[case] token: TestToken,
+    ) {
+        let mut account = new_account_native::create_account_and_call(
             &mut deployment,
+            token,
             U256::from(1),
             U256::from((1u128 << 112) - 1),
         )
         .unwrap();
 
         let amount = U256::from(1);
-        let (calldata, _) = prepare_call(&mut deployment, &mut shielder_account, amount);
-        let result = invoke_call(&mut deployment, &mut shielder_account, amount, &calldata);
+        let (calldata, _) = prepare_call(&mut deployment, &mut account, token, amount);
+        let result = invoke_call(&mut deployment, &mut account, token, amount, &calldata);
 
         assert_matches!(
             result,
@@ -199,73 +256,101 @@ mod tests {
         );
         assert!(actor_balance_decreased_by(
             &deployment,
+            token,
             U256::from((1u128 << 112) - 1)
         ))
     }
 
     #[rstest]
-    fn cannot_use_same_note_twice(mut deployment: Deployment) {
-        let mut shielder_account = new_account_native::create_account_and_call(
+    #[case::native(TestToken::Native)]
+    #[case::erc20(TestToken::FakeERC20)]
+    fn cannot_use_same_note_twice(mut deployment: Deployment, #[case] token: TestToken) {
+        let mut account = new_account_native::create_account_and_call(
             &mut deployment,
+            token,
             U256::from(1),
             U256::from(10),
         )
         .unwrap();
 
         let amount = U256::from(5);
-        let (calldata, _) = prepare_call(&mut deployment, &mut shielder_account, amount);
-        let result_1 = invoke_call(&mut deployment, &mut shielder_account, amount, &calldata);
+        let (calldata, _) = prepare_call(&mut deployment, &mut account, token, amount);
+        let result_1 = invoke_call(&mut deployment, &mut account, token, amount, &calldata);
         assert!(result_1.is_ok());
 
-        let result_2 = invoke_call(&mut deployment, &mut shielder_account, amount, &calldata);
+        let result_2 = invoke_call(&mut deployment, &mut account, token, amount, &calldata);
 
         assert_matches!(
             result_2,
             Err(ShielderContractErrors::DuplicatedNullifier(_))
         );
-        assert!(actor_balance_decreased_by(&deployment, U256::from(15)))
+        assert!(actor_balance_decreased_by(
+            &deployment,
+            token,
+            U256::from(15)
+        ))
     }
 
     #[rstest]
-    fn cannot_use_input_greater_than_field_modulus(mut deployment: Deployment) {
-        let mut shielder_account = new_account_native::create_account_and_call(
+    #[case::native(TestToken::Native)]
+    #[case::erc20(TestToken::FakeERC20)]
+    fn cannot_use_input_greater_than_field_modulus(
+        mut deployment: Deployment,
+        #[case] token: TestToken,
+    ) {
+        let mut account = new_account_native::create_account_and_call(
             &mut deployment,
+            token,
             U256::from(1),
             U256::from(10),
         )
         .unwrap();
 
         let amount = U256::from(5);
-        let (mut calldata, _) = prepare_call(&mut deployment, &mut shielder_account, amount);
+        let (mut calldata, _) = prepare_call(&mut deployment, &mut account, token, amount);
         let mut swap_value = U256::from_str(F::MODULUS).unwrap();
 
         mem::swap(&mut calldata.oldNullifierHash, &mut swap_value);
-        let result = invoke_call(&mut deployment, &mut shielder_account, amount, &calldata);
+        let result = invoke_call(&mut deployment, &mut account, token, amount, &calldata);
         assert_matches!(result, Err(ShielderContractErrors::NotAFieldElement(_)));
         mem::swap(&mut calldata.oldNullifierHash, &mut swap_value);
 
         mem::swap(&mut calldata.newNote, &mut swap_value);
-        let result = invoke_call(&mut deployment, &mut shielder_account, amount, &calldata);
+        let result = invoke_call(&mut deployment, &mut account, token, amount, &calldata);
         assert_matches!(result, Err(ShielderContractErrors::NotAFieldElement(_)));
         mem::swap(&mut calldata.newNote, &mut swap_value);
 
         mem::swap(&mut calldata.idHiding, &mut swap_value);
-        let result = invoke_call(&mut deployment, &mut shielder_account, amount, &calldata);
+        let result = invoke_call(&mut deployment, &mut account, token, amount, &calldata);
         assert_matches!(result, Err(ShielderContractErrors::NotAFieldElement(_)));
         mem::swap(&mut calldata.idHiding, &mut swap_value);
 
-        assert!(actor_balance_decreased_by(&deployment, U256::from(10)));
-        assert!(recipient_balance_increased_by(&deployment, U256::from(0)));
-        assert!(relayer_balance_increased_by(&deployment, U256::from(0)))
+        assert!(actor_balance_decreased_by(
+            &deployment,
+            token,
+            U256::from(10)
+        ));
+        assert!(recipient_balance_increased_by(
+            &deployment,
+            token,
+            U256::from(0)
+        ));
+        assert!(relayer_balance_increased_by(
+            &deployment,
+            token,
+            U256::from(0)
+        ))
     }
 
     #[rstest]
-    fn fails_if_merkle_root_does_not_exist(mut deployment: Deployment) {
-        let mut shielder_account = ShielderAccount::default();
+    #[case::native(TestToken::Native)]
+    #[case::erc20(TestToken::FakeERC20)]
+    fn fails_if_merkle_root_does_not_exist(mut deployment: Deployment, #[case] token: TestToken) {
+        let mut account = ShielderAccount::default();
 
         let calldata = depositCall {
             expectedContractVersion: FixedBytes([0, 1, 0]),
-            tokenAddress: Address::ZERO,
+            tokenAddress: token.address(&deployment),
             amount: U256::from(10),
             idHiding: U256::ZERO,
             oldNullifierHash: U256::ZERO,
@@ -275,7 +360,8 @@ mod tests {
         };
         let result = invoke_call(
             &mut deployment,
-            &mut shielder_account,
+            &mut account,
+            token,
             U256::from(10),
             &calldata,
         );
@@ -284,61 +370,78 @@ mod tests {
             result,
             Err(ShielderContractErrors::MerkleRootDoesNotExist(_))
         );
-        assert!(actor_balance_decreased_by(&deployment, U256::ZERO))
+        assert!(actor_balance_decreased_by(&deployment, token, U256::ZERO))
     }
 
     #[rstest]
-    fn fails_if_proof_incorrect(mut deployment: Deployment) {
-        let mut shielder_account = new_account_native::create_account_and_call(
+    #[case::native(TestToken::Native)]
+    #[case::erc20(TestToken::FakeERC20)]
+    fn fails_if_proof_incorrect(mut deployment: Deployment, #[case] token: TestToken) {
+        let mut account = new_account_native::create_account_and_call(
             &mut deployment,
+            token,
             U256::from(1),
             U256::from(10),
         )
         .unwrap();
 
         let amount = U256::from(5);
-        let (mut calldata, _) = prepare_call(&mut deployment, &mut shielder_account, amount);
+        let (mut calldata, _) = prepare_call(&mut deployment, &mut account, token, amount);
         calldata.proof = Bytes::from(vec![]);
-        let result = invoke_call(&mut deployment, &mut shielder_account, amount, &calldata);
+        let result = invoke_call(&mut deployment, &mut account, token, amount, &calldata);
 
         assert_matches!(
             result,
             Err(ShielderContractErrors::DepositVerificationFailed(_))
         );
-        assert!(actor_balance_decreased_by(&deployment, U256::from(10)))
+        assert!(actor_balance_decreased_by(
+            &deployment,
+            token,
+            U256::from(10)
+        ))
     }
 
     #[rstest]
-    fn rejects_value_zero(mut deployment: Deployment) {
+    #[case::native(TestToken::Native)]
+    #[case::erc20(TestToken::FakeERC20)]
+    fn rejects_value_zero(mut deployment: Deployment, #[case] token: TestToken) {
         let initial_amount = U256::from(10);
-        let mut shielder_account = new_account_native::create_account_and_call(
+        let mut account = new_account_native::create_account_and_call(
             &mut deployment,
+            token,
             U256::from(1),
             initial_amount,
         )
         .unwrap();
 
         let amount = U256::ZERO;
-        let (calldata, _) = prepare_call(&mut deployment, &mut shielder_account, amount);
-        let result = invoke_call(&mut deployment, &mut shielder_account, amount, &calldata);
+        let (calldata, _) = prepare_call(&mut deployment, &mut account, token, amount);
+        let result = invoke_call(&mut deployment, &mut account, token, amount, &calldata);
 
         assert_matches!(result, Err(ShielderContractErrors::ZeroAmount(_)));
-        assert!(actor_balance_decreased_by(&deployment, U256::from(10)))
+        assert!(actor_balance_decreased_by(
+            &deployment,
+            token,
+            U256::from(10)
+        ))
     }
 
     #[rstest]
-    fn fails_if_over_deposit_limit(mut deployment: Deployment) {
+    #[case::native(TestToken::Native)]
+    #[case::erc20(TestToken::FakeERC20)]
+    fn fails_if_over_deposit_limit(mut deployment: Deployment, #[case] token: TestToken) {
         let initial_amount = U256::from(101);
-        let mut shielder_account = new_account_native::create_account_and_call(
+        let mut account = new_account_native::create_account_and_call(
             &mut deployment,
+            token,
             U256::from(1),
             initial_amount,
         )
         .unwrap();
 
         let amount = U256::from(1);
-        let (calldata, _) = prepare_call(&mut deployment, &mut shielder_account, amount);
-        let result = invoke_call(&mut deployment, &mut shielder_account, amount, &calldata);
+        let (calldata, _) = prepare_call(&mut deployment, &mut account, token, amount);
+        let result = invoke_call(&mut deployment, &mut account, token, amount, &calldata);
 
         assert!(result.is_ok());
 
@@ -354,16 +457,17 @@ mod tests {
         assert_eq!(returned_new_limit, U256::from(100));
 
         let initial_amount = U256::from(10);
-        let mut shielder_account = new_account_native::create_account_and_call(
+        let mut account = new_account_native::create_account_and_call(
             &mut deployment,
+            token,
             U256::from(2),
             initial_amount,
         )
         .unwrap();
 
         let amount = U256::from(101);
-        let (calldata, _) = prepare_call(&mut deployment, &mut shielder_account, amount);
-        let result = invoke_call(&mut deployment, &mut shielder_account, amount, &calldata);
+        let (calldata, _) = prepare_call(&mut deployment, &mut account, token, amount);
+        let result = invoke_call(&mut deployment, &mut account, token, amount, &calldata);
 
         assert_matches!(
             result,

--- a/crates/integration-tests/src/shielder/calls/deposit_native.rs
+++ b/crates/integration-tests/src/shielder/calls/deposit_native.rs
@@ -1,4 +1,5 @@
 // TODO: Rename to `deposit.rs` since no longer testing just native.
+
 use std::str::FromStr;
 
 use alloy_primitives::{Address, TxHash, U256};

--- a/crates/integration-tests/src/shielder/calls/new_account_native.rs
+++ b/crates/integration-tests/src/shielder/calls/new_account_native.rs
@@ -1,4 +1,5 @@
 // TODO: Rename to `new_account.rs` since no longer testing just native.
+
 use std::str::FromStr;
 
 use alloy_primitives::{Address, TxHash, U256};

--- a/crates/integration-tests/src/shielder/calls/withdraw_native.rs
+++ b/crates/integration-tests/src/shielder/calls/withdraw_native.rs
@@ -1,4 +1,5 @@
 // TODO: Rename to `withdraw.rs` since no longer testing just native.
+
 use std::str::FromStr;
 
 use alloy_primitives::{Address, TxHash, U256};

--- a/crates/integration-tests/src/shielder/deploy.rs
+++ b/crates/integration-tests/src/shielder/deploy.rs
@@ -7,11 +7,12 @@ use evm_utils::{
     revm_primitives::{AccountInfo, Bytecode},
     EvmRunner,
 };
-use rstest::{fixture, rstest};
+use rstest::fixture;
 use shielder_contract::ShielderContract::initializeCall;
 
 use crate::{
     deploy_contract,
+    fake_token::FakeToken,
     proving_utils::{
         deposit_proving_params, new_account_proving_params, withdraw_proving_params, ProvingParams,
     },
@@ -23,31 +24,37 @@ use crate::{
     verifier::deploy_verifiers,
 };
 
+pub const FAKE_TOKEN_FAUCET_ADDRESS: &str = "9999999999999999999999999999999999999999";
+
 /// The address of the deployer account.
 ///
 /// This is one of the default accounts in the Anvil testnet.
 pub const DEPLOYER_ADDRESS: &str = "f39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
-pub const DEPLOYER_INITIAL_BALANCE: U256 = U256::MAX;
+pub const DEPLOYER_INITIAL_NATIVE_BALANCE: U256 = U256::MAX;
+pub const DEPLOYER_INITIAL_FAKE_TOKEN_BALANCE: U256 = U256::ZERO;
 
 /// The address of the actor account.
 ///
 /// This is one of the default accounts in the Anvil testnet.
 pub const ACTOR_ADDRESS: &str = "70997970C51812dc3A010C7d01b50e0d17dc79C8";
-pub const ACTOR_INITIAL_BALANCE: U256 = U256::MAX;
+pub const ACTOR_INITIAL_NATIVE_BALANCE: U256 = U256::MAX;
+pub const ACTOR_INITIAL_FAKE_TOKEN_BALANCE: U256 = U256::MAX;
 
 /// The private key of the actor account.
 pub const ACTOR_PRIVATE_KEY: &str =
     "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
 
 pub const RECIPIENT_ADDRESS: &str = "70997970C51812dc3A010C7d01b50e0d17dc79C9";
-pub const RECIPIENT_INITIAL_BALANCE: U256 = U256::ZERO;
+pub const RECIPIENT_INITIAL_NATIVE_BALANCE: U256 = U256::ZERO;
+pub const RECIPIENT_INITIAL_FAKE_TOKEN_BALANCE: U256 = U256::ZERO;
 
 pub const RELAYER_ADDRESS: &str = "70997970C51812dc3A010C7d01b50e0d17dc79CA";
-pub const RELAYER_INITIAL_BALANCE: U256 = U256::ZERO;
+pub const RELAYER_INITIAL_NATIVE_BALANCE: U256 = U256::ZERO;
+pub const RELAYER_INITIAL_FAKE_TOKEN_BALANCE: U256 = U256::ZERO;
 
 // Will always revert when receiving funds.
-pub const REVERTING_ADDRESS: &str = "70997970C51812dc3A010C7d01b50e0d17dc79CB";
-pub const REVERTING_ADDRESS_INITIAL_BALANCE: U256 = U256::ZERO;
+pub const REVERTING_ADDRESS: &str = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
+pub const REVERTING_ADDRESS_INITIAL_NATIVE_BALANCE: U256 = U256::ZERO;
 pub const REVERTING_BYTECODE: [u8; 4] = [0x60, 0x00, 0x80, 0xfd]; // PUSH1 0x00 DUP1 REVERT
 
 pub const INITIAL_DEPOSIT_LIMIT: U256 = U256::MAX;
@@ -59,21 +66,29 @@ pub struct ShielderContractSuite {
 
 pub fn prepare_account(
     evm: &mut EvmRunner,
+    fake_token: &FakeToken,
     address: &str,
-    balance: U256,
+    native_balance: U256,
+    fake_token_balance: Option<U256>,
     code: Option<Bytecode>,
 ) -> Address {
-    let caller = Address::from_str(address).unwrap();
+    let address = Address::from_str(address).unwrap();
+
     evm.db.insert_account_info(
-        caller,
+        address,
         AccountInfo {
             nonce: 0_u64,
-            balance,
+            balance: native_balance,
             code_hash: keccak256(Bytes::new()),
             code,
         },
     );
-    caller
+
+    if let Some(balance) = fake_token_balance {
+        fake_token.faucet(evm, address, balance).unwrap()
+    }
+
+    address
 }
 
 /// Solc leaves this placeholder for a Poseidon2 contract address.
@@ -84,6 +99,7 @@ const WITHDRAW_VERIFIER_LIB_PLACEHOLDER: &str = "__$06bb88608c3ade14b496e12c6067
 
 pub struct Deployment {
     pub evm: EvmRunner,
+    pub fake_token: FakeToken,
     pub contract_suite: ShielderContractSuite,
     pub new_account_proving_params: ProvingParams,
     pub deposit_proving_params: ProvingParams,
@@ -98,15 +114,51 @@ pub fn deployment(
     withdraw_proving_params: &ProvingParams,
 ) -> Deployment {
     let mut evm = EvmRunner::aleph_evm();
-    let owner = prepare_account(&mut evm, DEPLOYER_ADDRESS, DEPLOYER_INITIAL_BALANCE, None);
-    prepare_account(&mut evm, ACTOR_ADDRESS, ACTOR_INITIAL_BALANCE, None);
-    prepare_account(&mut evm, RECIPIENT_ADDRESS, RECIPIENT_INITIAL_BALANCE, None);
-    prepare_account(&mut evm, RELAYER_ADDRESS, RELAYER_INITIAL_BALANCE, None);
+
+    let fake_token = FakeToken::deploy(
+        &mut evm,
+        Address::from_str(FAKE_TOKEN_FAUCET_ADDRESS).unwrap(),
+    );
+
+    let owner = prepare_account(
+        &mut evm,
+        &fake_token,
+        DEPLOYER_ADDRESS,
+        DEPLOYER_INITIAL_NATIVE_BALANCE,
+        Some(DEPLOYER_INITIAL_FAKE_TOKEN_BALANCE),
+        None,
+    );
+    prepare_account(
+        &mut evm,
+        &fake_token,
+        ACTOR_ADDRESS,
+        ACTOR_INITIAL_NATIVE_BALANCE,
+        Some(ACTOR_INITIAL_FAKE_TOKEN_BALANCE),
+        None,
+    );
+    prepare_account(
+        &mut evm,
+        &fake_token,
+        RECIPIENT_ADDRESS,
+        RECIPIENT_INITIAL_NATIVE_BALANCE,
+        Some(RECIPIENT_INITIAL_FAKE_TOKEN_BALANCE),
+        None,
+    );
+    prepare_account(
+        &mut evm,
+        &fake_token,
+        RELAYER_ADDRESS,
+        RELAYER_INITIAL_NATIVE_BALANCE,
+        Some(RELAYER_INITIAL_FAKE_TOKEN_BALANCE),
+        None,
+    );
     let reverting_bytecode = Bytecode::new_raw(Bytes::from_static(&REVERTING_BYTECODE));
     prepare_account(
         &mut evm,
+        &fake_token,
         REVERTING_ADDRESS,
-        REVERTING_ADDRESS_INITIAL_BALANCE,
+        REVERTING_ADDRESS_INITIAL_NATIVE_BALANCE,
+        None, // Cannot transfer to this address because `FakeERC20Token` will revert.
         Some(reverting_bytecode),
     );
 
@@ -115,6 +167,7 @@ pub fn deployment(
 
     Deployment {
         evm,
+        fake_token,
         contract_suite: ShielderContractSuite {
             shielder: shielder_address,
         },
@@ -203,7 +256,14 @@ pub fn deploy_shielder_contract(evm: &mut EvmRunner, owner: Address) -> Address 
         .expect("Failed to deploy Shielder contract through a proxy")
 }
 
-#[rstest]
-fn deploy_shielder_suite(_deployment: Deployment) {
-    // Deployment successful.
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use crate::deploy::{deployment, Deployment};
+
+    #[rstest]
+    fn deploy_shielder_suite(_deployment: Deployment) {
+        // Deployment successful.
+    }
 }

--- a/crates/integration-tests/src/shielder/fake_token.rs
+++ b/crates/integration-tests/src/shielder/fake_token.rs
@@ -1,0 +1,138 @@
+use alloy_primitives::{Address, U256};
+use alloy_sol_types::{SolCall, SolValue};
+use evm_utils::{EvmRunner, EvmRunnerError};
+
+use crate::{deploy_contract_with_caller, ierc20::IERC20};
+
+pub struct FakeToken {
+    pub contract_address: Address,
+    pub faucet_address: Address,
+}
+
+impl FakeToken {
+    pub fn deploy(evm: &mut EvmRunner, faucet_address: Address) -> FakeToken {
+        let contract_address = deploy_contract_with_caller(
+            "FakeERC20Token.sol",
+            "FakeERC20Token",
+            Some(faucet_address),
+            evm,
+        );
+
+        FakeToken {
+            contract_address,
+            faucet_address,
+        }
+    }
+
+    pub fn faucet(
+        &self,
+        evm: &mut EvmRunner,
+        to: Address,
+        value: U256,
+    ) -> Result<(), EvmRunnerError> {
+        let calldata = IERC20::transferCall { to, value };
+        evm.call(
+            self.contract_address,
+            calldata.abi_encode(),
+            Some(self.faucet_address),
+            None,
+        )?;
+        Ok(())
+    }
+
+    pub fn get_balance(
+        &self,
+        evm: &EvmRunner,
+        address: Address,
+    ) -> Result<U256, alloy_sol_types::Error> {
+        let calldata = IERC20::balanceOfCall { account: address };
+        let result = evm
+            .call_ref(self.contract_address, calldata.abi_encode(), None, None)
+            .unwrap();
+        <U256>::abi_decode(&result.output, true)
+    }
+
+    pub fn approve(
+        &self,
+        evm: &mut EvmRunner,
+        owner: Address,
+        spender: Address,
+        value: U256,
+    ) -> Result<(), EvmRunnerError> {
+        let calldata = IERC20::approveCall { spender, value };
+        evm.call(
+            self.contract_address,
+            calldata.abi_encode(),
+            Some(owner),
+            None,
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use alloy_primitives::{Address, U256};
+    use alloy_sol_types::SolCall;
+    use evm_utils::EvmRunner;
+
+    use super::FakeToken;
+    use crate::ierc20::IERC20;
+
+    const FAUCET_ADDRESS: &str = "5555555555555555555555555555555555555555";
+    const ACTOR_ADDRESS: &str = "6666666666666666666666666666666666666666";
+    const RECIPIENT_ADDRESS: &str = "7777777777777777777777777777777777777777";
+
+    #[test]
+    fn faucet_works() {
+        let faucet_address = Address::from_str(FAUCET_ADDRESS).unwrap();
+        let recipient_address = Address::from_str(RECIPIENT_ADDRESS).unwrap();
+
+        let mut evm = EvmRunner::aleph_evm();
+        let fake_token = FakeToken::deploy(&mut evm, faucet_address);
+
+        assert!(fake_token
+            .faucet(&mut evm, recipient_address, U256::from(123))
+            .is_ok());
+
+        assert_eq!(
+            fake_token.get_balance(&evm, recipient_address).unwrap(),
+            U256::from(123)
+        );
+    }
+
+    #[test]
+    fn approve_works() {
+        let faucet_address = Address::from_str(FAUCET_ADDRESS).unwrap();
+        let actor_address = Address::from_str(ACTOR_ADDRESS).unwrap();
+        let recipient_address = Address::from_str(RECIPIENT_ADDRESS).unwrap();
+
+        let mut evm = EvmRunner::aleph_evm();
+        let fake_token = FakeToken::deploy(&mut evm, faucet_address);
+
+        assert!(fake_token
+            .approve(&mut evm, faucet_address, actor_address, U256::from(123))
+            .is_ok());
+
+        let calldata = IERC20::transferFromCall {
+            from: faucet_address,
+            to: recipient_address,
+            value: U256::from(123),
+        };
+        assert!(evm
+            .call(
+                fake_token.contract_address,
+                calldata.abi_encode(),
+                Some(actor_address),
+                None
+            )
+            .is_ok());
+
+        assert_eq!(
+            fake_token.get_balance(&evm, recipient_address).unwrap(),
+            U256::from(123)
+        );
+    }
+}

--- a/crates/integration-tests/src/shielder/ierc20.rs
+++ b/crates/integration-tests/src/shielder/ierc20.rs
@@ -1,0 +1,24 @@
+// Copied from:
+// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/IERC20.sol
+
+use alloy_sol_types::sol;
+
+sol! {
+    interface IERC20 {
+        event Transfer(address indexed from, address indexed to, uint256 value);
+
+        event Approval(address indexed owner, address indexed spender, uint256 value);
+
+        function totalSupply() external view returns (uint256);
+
+        function balanceOf(address account) external view returns (uint256);
+
+        function transfer(address to, uint256 value) external returns (bool);
+
+        function allowance(address owner, address spender) external view returns (uint256);
+
+        function approve(address spender, uint256 value) external returns (bool);
+
+        function transferFrom(address from, address to, uint256 value) external returns (bool);
+    }
+}

--- a/crates/integration-tests/src/shielder/merkle.rs
+++ b/crates/integration-tests/src/shielder/merkle.rs
@@ -47,13 +47,14 @@ mod tests {
     use crate::shielder::{
         calls::new_account_native,
         deploy::{deployment, Deployment},
-        invoke_shielder_call,
+        invoke_shielder_call, TestToken,
     };
 
     #[rstest]
     fn succeeds(mut deployment: Deployment) {
         assert!(new_account_native::create_account_and_call(
             &mut deployment,
+            TestToken::Native,
             U256::from(1),
             U256::from(10)
         )


### PR DESCRIPTION
TLDR: in `integration-tests`, we deploy `FakeERC20Token` contract and use it in new tests.

Notes:
- Modifying `Shielder.sol` because in previous version `revert ERC20TransferFailed()` was impossible to trigger.
- Adding `call_ref` to `EvmRunner` because `call` uses `&mut self` and we want to call `ERC20::balanceOf` with `&self`.
- Leaving rename of `{deposit,withdraw,new_account}_native.rs` for another PR.
- Adding a license because this PR adds code copied from OpenZeppelin.