### PR TITLE
ZK-714: Split contract calls

### DIFF
--- a/.github/workflows/_measure-gas.yml
+++ b/.github/workflows/_measure-gas.yml
@@ -57,7 +57,9 @@ jobs:
           path: main
 
       - name: Build binary
-        run: cargo build -p integration-tests --bin gas-consumption --release
+        run: |
+          cd main
+          cargo build -p integration-tests --bin gas-consumption --release
 
       - name: Install dependencies
         run: |
@@ -73,7 +75,7 @@ jobs:
         run: |
           export CONTRACTS_DIR="main/contracts"
           export CARGO_MANIFEST_DIR=./main/Cargo.toml
-          ./target/release/gas-consumption main-report.txt
+          ./main/target/release/gas-consumption main-report.txt
 
       - name: Print gas measured on the `main` branch
         run: cat main-report.txt

--- a/.github/workflows/_measure-gas.yml
+++ b/.github/workflows/_measure-gas.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   main:
-    name: Measure circuits
+    name: Measure gas
     runs-on: [self-hosted, Linux, X64, large]
     timeout-minutes: 20
     steps:
@@ -28,10 +28,10 @@ jobs:
         with:
           solc-version: 0.8.26
 
+      #################### Run measurements on the current branch ####################
+
       - name: Build binary
         run: cargo build -p integration-tests --bin gas-consumption --release
-
-      #################### Run measurements on the current branch ####################
 
       - name: Install dependencies
         run: make deps
@@ -39,7 +39,7 @@ jobs:
       - name: Generate all contracts
         run: make generate-contracts
 
-      - name: Run measure-circuits binary on the current branch
+      - name: Run gas-consumption binary on the current branch
         run: |
           export CONTRACTS_DIR="contracts"
           export CARGO_MANIFEST_DIR=./Cargo.toml
@@ -56,6 +56,9 @@ jobs:
           ref: main
           path: main
 
+      - name: Build binary
+        run: cargo build -p integration-tests --bin gas-consumption --release
+
       - name: Install dependencies
         run: |
           cd main
@@ -66,7 +69,7 @@ jobs:
           cd main
           make generate-contracts
 
-      - name: Run measure-circuits on the `main` branch
+      - name: Run gas-consumption on the `main` branch
         run: |
           export CONTRACTS_DIR="main/contracts"
           export CARGO_MANIFEST_DIR=./main/Cargo.toml

--- a/contracts/Shielder.sol
+++ b/contracts/Shielder.sol
@@ -12,6 +12,9 @@ import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/acc
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+using SafeERC20 for IERC20;
 
 /// @title Shielder
 /// @author CardinalCryptography
@@ -87,7 +90,6 @@ contract Shielder is
     error FeeHigherThanAmount();
     error MerkleRootDoesNotExist();
     error NativeTransferFailed();
-    error ERC20TransferFailed();
     error WithdrawVerificationFailed();
     error NewAccountVerificationFailed();
     error ZeroAmount();
@@ -95,7 +97,6 @@ contract Shielder is
     error ContractBalanceLimitReached();
     error WrongContractVersion(bytes3 actual, bytes3 expectedByCaller);
     error NotAFieldElement();
-    error IncorrectNativeAmount();
 
     modifier restrictContractVersion(bytes3 expectedByCaller) {
         if (expectedByCaller != CONTRACT_VERSION) {
@@ -135,10 +136,62 @@ contract Shielder is
     }
 
     /*
-     * Creates a fresh note, with an optional token deposit.
+     * Creates a fresh note, with an optional native token deposit.
      *
-     * This transaction serves as the entrypoint to the Shielder.
+     * This transaction serves as an entrypoint to the Shielder.
      */
+    function newAccountNative(
+        bytes3 expectedContractVersion,
+        uint256 newNote,
+        uint256 idHash,
+        bytes calldata proof
+    ) external payable whenNotPaused {
+        uint256 amount = msg.value;
+        // `address(this).balance` already includes `msg.value`.
+        if (address(this).balance > MAX_CONTRACT_BALANCE) {
+            revert ContractBalanceLimitReached();
+        }
+
+        newAccount(
+            expectedContractVersion,
+            address(0),
+            amount,
+            newNote,
+            idHash,
+            proof
+        );
+    }
+
+    /*
+     * Creates a fresh note, with an optional ERC20 token deposit.
+     *
+     * This transaction serves as an entrypoint to the Shielder.
+     */
+    function newAccountERC20(
+        bytes3 expectedContractVersion,
+        address tokenAddress,
+        uint256 amount,
+        uint256 newNote,
+        uint256 idHash,
+        bytes calldata proof
+    ) external whenNotPaused {
+        IERC20 token = IERC20(tokenAddress);
+        token.safeTransferFrom(msg.sender, address(this), amount);
+
+        if (token.balanceOf(address(this)) > MAX_CONTRACT_BALANCE) {
+            revert ContractBalanceLimitReached();
+        }
+
+        newAccount(
+            expectedContractVersion,
+            tokenAddress,
+            amount,
+            newNote,
+            idHash,
+            proof
+        );
+    }
+
     function newAccount(
         bytes3 expectedContractVersion,
         address tokenAddress,
@@ -147,15 +200,13 @@ contract Shielder is
         uint256 idHash,
         bytes calldata proof
     )
-        external
-        payable
+        internal
         whenNotPaused
         restrictContractVersion(expectedContractVersion)
         fieldElement(newNote)
         fieldElement(idHash)
     {
         if (amount > depositLimit()) revert AmountOverDepositLimit();
-        handleTokenTransferIn(tokenAddress, amount);
 
         if (nullifiers(idHash) != 0) revert DuplicatedNullifier();
         // @dev must follow the same order as in the circuit
@@ -182,8 +233,62 @@ contract Shielder is
     }
 
     /*
-     * Make a token deposit into the Shielder
+     * Makes a native token deposit into the Shielder.
      */
+    function depositNative(
+        bytes3 expectedContractVersion,
+        uint256 idHiding,
+        uint256 oldNullifierHash,
+        uint256 newNote,
+        uint256 merkleRoot,
+        bytes calldata proof
+    ) external payable whenNotPaused {
+        uint256 amount = msg.value;
+        if (address(this).balance > MAX_CONTRACT_BALANCE) {
+            revert ContractBalanceLimitReached();
+        }
+        deposit(
+            expectedContractVersion,
+            address(0),
+            amount,
+            idHiding,
+            oldNullifierHash,
+            newNote,
+            merkleRoot,
+            proof
+        );
+    }
+
+    /*
+     * Makes an ERC20 token deposit into the Shielder.
+     */
+    function depositERC20(
+        bytes3 expectedContractVersion,
+        address tokenAddress,
+        uint256 amount,
+        uint256 idHiding,
+        uint256 oldNullifierHash,
+        uint256 newNote,
+        uint256 merkleRoot,
+        bytes calldata proof
+    ) external whenNotPaused {
+        IERC20 token = IERC20(tokenAddress);
+        token.safeTransferFrom(msg.sender, address(this), amount);
+        if (token.balanceOf(address(this)) > MAX_CONTRACT_BALANCE) {
+            revert ContractBalanceLimitReached();
+        }
+        deposit(
+            expectedContractVersion,
+            tokenAddress,
+            amount,
+            idHiding,
+            oldNullifierHash,
+            newNote,
+            merkleRoot,
+            proof
+        );
+    }
+
     function deposit(
         bytes3 expectedContractVersion,
         address tokenAddress,
@@ -194,16 +299,13 @@ contract Shielder is
         uint256 merkleRoot,
         bytes calldata proof
     )
-        external
-        payable
+        internal
         restrictContractVersion(expectedContractVersion)
         fieldElement(idHiding)
         fieldElement(oldNullifierHash)
         fieldElement(newNote)
-        whenNotPaused
     {
         if (amount > depositLimit()) revert AmountOverDepositLimit();
-        handleTokenTransferIn(tokenAddress, amount);
         if (amount == 0) revert ZeroAmount();
         if (nullifiers(oldNullifierHash) != 0) revert DuplicatedNullifier();
         if (!_merkleRootExists(merkleRoot)) revert MerkleRootDoesNotExist();
@@ -234,8 +336,79 @@ contract Shielder is
     }
 
     /*
-     * Withdraw shielded funds
+     * Withdraw shielded native funds
      */
+    function withdrawNative(
+        bytes3 expectedContractVersion,
+        uint256 idHiding,
+        uint256 amount,
+        address withdrawalAddress,
+        uint256 merkleRoot,
+        uint256 oldNullifierHash,
+        uint256 newNote,
+        bytes calldata proof,
+        address relayerAddress,
+        uint256 relayerFee
+    ) external whenNotPaused {
+        withdraw(
+            expectedContractVersion,
+            idHiding,
+            address(0),
+            amount,
+            withdrawalAddress,
+            merkleRoot,
+            oldNullifierHash,
+            newNote,
+            proof,
+            relayerAddress,
+            relayerFee
+        );
+        // return the tokens
+        (bool nativeTransferSuccess, ) = withdrawalAddress.call{
+            value: amount - relayerFee,
+            gas: GAS_LIMIT
+        }("");
+        if (!nativeTransferSuccess) revert NativeTransferFailed();
+
+        // pay out the fee
+        (nativeTransferSuccess, ) = relayerAddress.call{
+            value: relayerFee,
+            gas: GAS_LIMIT
+        }("");
+        if (!nativeTransferSuccess) revert NativeTransferFailed();
+    }
+
+    function withdrawERC20(
+        bytes3 expectedContractVersion,
+        uint256 idHiding,
+        address tokenAddress,
+        uint256 amount,
+        address withdrawalAddress,
+        uint256 merkleRoot,
+        uint256 oldNullifierHash,
+        uint256 newNote,
+        bytes calldata proof,
+        address relayerAddress,
+        uint256 relayerFee
+    ) external whenNotPaused {
+        withdraw(
+            expectedContractVersion,
+            idHiding,
+            tokenAddress,
+            amount,
+            withdrawalAddress,
+            merkleRoot,
+            oldNullifierHash,
+            newNote,
+            proof,
+            relayerAddress,
+            relayerFee
+        );
+        IERC20 token = IERC20(tokenAddress);
+        token.safeTransfer(withdrawalAddress, amount - relayerFee);
+        token.safeTransfer(relayerAddress, relayerFee);
+    }
+
     function withdraw(
         bytes3 expectedContractVersion,
         uint256 idHiding,
@@ -249,8 +422,7 @@ contract Shielder is
         address relayerAddress,
         uint256 relayerFee
     )
-        external
-        whenNotPaused
+        internal
         restrictContractVersion(expectedContractVersion)
         fieldElement(idHiding)
         fieldElement(oldNullifierHash)
@@ -287,13 +459,6 @@ contract Shielder is
         uint256 newNoteIndex = _addNote(newNote);
         _registerNullifier(oldNullifierHash);
 
-        handleTokenTransferOut(
-            tokenAddress,
-            withdrawalAddress,
-            amount - relayerFee
-        );
-        handleTokenTransferOut(tokenAddress, relayerAddress, relayerFee);
-
         emit Withdraw(
             CONTRACT_VERSION,
             idHiding,
@@ -323,41 +488,5 @@ contract Shielder is
      */
     function setDepositLimit(uint256 _depositLimit) external onlyOwner {
         _setDepositLimit(_depositLimit);
-    }
-
-    function handleTokenTransferIn(
-        address tokenAddress,
-        uint256 amount
-    ) internal {
-        if (tokenAddress == address(0)) {
-            if (amount != msg.value) {
-                revert IncorrectNativeAmount();
-            }
-            // `address(this).balance` already includes `msg.value`.
-            if (address(this).balance > MAX_CONTRACT_BALANCE) {
-                revert ContractBalanceLimitReached();
-            }
-        } else {
-            IERC20 token = IERC20(tokenAddress);
-            token.transferFrom(msg.sender, address(this), amount);
-            if (token.balanceOf(address(this)) > MAX_CONTRACT_BALANCE) {
-                revert ContractBalanceLimitReached();
-            }
-        }
-    }
-
-    function handleTokenTransferOut(
-        address tokenAddress,
-        address to,
-        uint256 amount
-    ) internal {
-        if (tokenAddress == address(0)) {
-            (bool success, ) = to.call{ value: amount, gas: GAS_LIMIT }("");
-            if (!success) revert NativeTransferFailed();
-        } else {
-            IERC20 token = IERC20(tokenAddress);
-            bool transferSuccess = token.transfer(to, amount);
-            if (!transferSuccess) revert ERC20TransferFailed();
-        }
     }
 }

--- a/contracts/Shielder.sol
+++ b/contracts/Shielder.sol
@@ -186,9 +186,10 @@ contract Shielder is
         bytes calldata proof
     ) external whenNotPaused {
         IERC20 token = IERC20(tokenAddress);
-        token.safeTransferFrom(msg.sender, address(this), amount);
-
-        if (token.balanceOf(address(this)) > MAX_CONTRACT_BALANCE) {
+        if (
+            amount > MAX_CONTRACT_BALANCE ||
+            token.balanceOf(address(this)) + amount > MAX_CONTRACT_BALANCE
+        ) {
             revert ContractBalanceLimitReached();
         }
 
@@ -201,6 +202,8 @@ contract Shielder is
             symKeyEncryption,
             proof
         );
+
+        token.safeTransferFrom(msg.sender, address(this), amount);
     }
 
     function _newAccount(

--- a/contracts/Shielder.sol
+++ b/contracts/Shielder.sol
@@ -56,6 +56,9 @@ contract Shielder is
     uint256 private constant FIELD_MODULUS =
         21888242871839275222246405745257275088548364400416034343698204186575808495617;
 
+    /// A special value of `tokenAddress` in circuits used to represent the native token.
+    address private constant NATIVE_TOKEN_NOTE_ADDRESS = address(0);
+
     // -- Events --
     event NewAccount(
         bytes3 contractVersion,
@@ -148,6 +151,7 @@ contract Shielder is
         bytes3 expectedContractVersion,
         uint256 newNote,
         uint256 idHash,
+        uint256 symKeyEncryption,
         bytes calldata proof
     ) external payable whenNotPaused {
         uint256 amount = msg.value;
@@ -158,10 +162,11 @@ contract Shielder is
 
         newAccount(
             expectedContractVersion,
-            address(0),
+            NATIVE_TOKEN_NOTE_ADDRESS,
             amount,
             newNote,
             idHash,
+            symKeyEncryption,
             proof
         );
     }
@@ -177,6 +182,7 @@ contract Shielder is
         uint256 amount,
         uint256 newNote,
         uint256 idHash,
+        uint256 symKeyEncryption,
         bytes calldata proof
     ) external whenNotPaused {
         IERC20 token = IERC20(tokenAddress);
@@ -192,6 +198,7 @@ contract Shielder is
             amount,
             newNote,
             idHash,
+            symKeyEncryption,
             proof
         );
     }
@@ -206,7 +213,6 @@ contract Shielder is
         bytes calldata proof
     )
         internal
-        whenNotPaused
         restrictContractVersion(expectedContractVersion)
         fieldElement(newNote)
         fieldElement(idHash)
@@ -258,7 +264,7 @@ contract Shielder is
         }
         deposit(
             expectedContractVersion,
-            address(0),
+            NATIVE_TOKEN_NOTE_ADDRESS,
             amount,
             idHiding,
             oldNullifierHash,
@@ -363,7 +369,7 @@ contract Shielder is
         withdraw(
             expectedContractVersion,
             idHiding,
-            address(0),
+            NATIVE_TOKEN_NOTE_ADDRESS,
             amount,
             withdrawalAddress,
             merkleRoot,

--- a/contracts/Shielder.sol
+++ b/contracts/Shielder.sol
@@ -160,7 +160,7 @@ contract Shielder is
             revert ContractBalanceLimitReached();
         }
 
-        newAccount(
+        _newAccount(
             expectedContractVersion,
             NATIVE_TOKEN_NOTE_ADDRESS,
             amount,
@@ -192,7 +192,7 @@ contract Shielder is
             revert ContractBalanceLimitReached();
         }
 
-        newAccount(
+        _newAccount(
             expectedContractVersion,
             tokenAddress,
             amount,
@@ -203,7 +203,7 @@ contract Shielder is
         );
     }
 
-    function newAccount(
+    function _newAccount(
         bytes3 expectedContractVersion,
         address tokenAddress,
         uint256 amount,
@@ -212,7 +212,7 @@ contract Shielder is
         uint256 symKeyEncryption,
         bytes calldata proof
     )
-        internal
+        private
         restrictContractVersion(expectedContractVersion)
         fieldElement(newNote)
         fieldElement(idHash)
@@ -262,7 +262,7 @@ contract Shielder is
         if (address(this).balance > MAX_CONTRACT_BALANCE) {
             revert ContractBalanceLimitReached();
         }
-        deposit(
+        _deposit(
             expectedContractVersion,
             NATIVE_TOKEN_NOTE_ADDRESS,
             amount,
@@ -292,7 +292,7 @@ contract Shielder is
         if (token.balanceOf(address(this)) > MAX_CONTRACT_BALANCE) {
             revert ContractBalanceLimitReached();
         }
-        deposit(
+        _deposit(
             expectedContractVersion,
             tokenAddress,
             amount,
@@ -304,7 +304,7 @@ contract Shielder is
         );
     }
 
-    function deposit(
+    function _deposit(
         bytes3 expectedContractVersion,
         address tokenAddress,
         uint256 amount,
@@ -314,7 +314,7 @@ contract Shielder is
         uint256 merkleRoot,
         bytes calldata proof
     )
-        internal
+        private
         restrictContractVersion(expectedContractVersion)
         fieldElement(idHiding)
         fieldElement(oldNullifierHash)
@@ -366,7 +366,7 @@ contract Shielder is
         address relayerAddress,
         uint256 relayerFee
     ) external whenNotPaused {
-        withdraw(
+        _withdraw(
             expectedContractVersion,
             idHiding,
             NATIVE_TOKEN_NOTE_ADDRESS,
@@ -407,7 +407,7 @@ contract Shielder is
         address relayerAddress,
         uint256 relayerFee
     ) external whenNotPaused {
-        withdraw(
+        _withdraw(
             expectedContractVersion,
             idHiding,
             tokenAddress,
@@ -425,7 +425,7 @@ contract Shielder is
         token.safeTransfer(relayerAddress, relayerFee);
     }
 
-    function withdraw(
+    function _withdraw(
         bytes3 expectedContractVersion,
         uint256 idHiding,
         address tokenAddress,
@@ -438,7 +438,7 @@ contract Shielder is
         address relayerAddress,
         uint256 relayerFee
     )
-        internal
+        private
         restrictContractVersion(expectedContractVersion)
         fieldElement(idHiding)
         fieldElement(oldNullifierHash)

--- a/contracts/Shielder.sol
+++ b/contracts/Shielder.sol
@@ -288,8 +288,10 @@ contract Shielder is
         bytes calldata proof
     ) external whenNotPaused {
         IERC20 token = IERC20(tokenAddress);
-        token.safeTransferFrom(msg.sender, address(this), amount);
-        if (token.balanceOf(address(this)) > MAX_CONTRACT_BALANCE) {
+        if (
+            amount > MAX_CONTRACT_BALANCE ||
+            token.balanceOf(address(this)) + amount > MAX_CONTRACT_BALANCE
+        ) {
             revert ContractBalanceLimitReached();
         }
         _deposit(
@@ -302,6 +304,7 @@ contract Shielder is
             merkleRoot,
             proof
         );
+        token.safeTransferFrom(msg.sender, address(this), amount);
     }
 
     function _deposit(

--- a/crates/integration-tests/src/bin/gas_consumption.rs
+++ b/crates/integration-tests/src/bin/gas_consumption.rs
@@ -19,13 +19,15 @@ use integration_tests::{
     deposit_proving_params, new_account_proving_params, withdraw_proving_params,
 };
 use shielder_account::ShielderAccount;
-use shielder_contract::ShielderContract::{depositCall, newAccountCall, withdrawCall};
+use shielder_contract::ShielderContract::{
+    depositNativeCall, newAccountNativeCall, withdrawNativeCall,
+};
 
 #[derive(Debug)]
 enum Calldata {
-    NewAccount(newAccountCall),
-    Deposit(depositCall),
-    Withdraw(withdrawCall),
+    NewAccount(newAccountNativeCall),
+    Deposit(depositNativeCall),
+    Withdraw(withdrawNativeCall),
 }
 
 impl fmt::Display for Calldata {

--- a/crates/integration-tests/src/shielder/calls/deposit_native.rs
+++ b/crates/integration-tests/src/shielder/calls/deposit_native.rs
@@ -3,7 +3,7 @@ use shielder_account::{
     call_data::{DepositCallType, MerkleProof},
     ShielderAccount,
 };
-use shielder_contract::ShielderContract::depositCall;
+use shielder_contract::ShielderContract::depositNativeCall;
 
 use crate::shielder::{
     deploy::Deployment, invoke_shielder_call, merkle::get_merkle_args, CallResult,
@@ -12,7 +12,7 @@ pub fn prepare_call(
     deployment: &mut Deployment,
     shielder_account: &mut ShielderAccount,
     amount: U256,
-) -> (depositCall, U256) {
+) -> (depositNativeCall, U256) {
     let note_index = shielder_account
         .current_leaf_index()
         .expect("No leaf index");
@@ -39,7 +39,7 @@ pub fn invoke_call(
     deployment: &mut Deployment,
     shielder_account: &mut ShielderAccount,
     amount: U256,
-    calldata: &depositCall,
+    calldata: &depositNativeCall,
 ) -> CallResult {
     let call_result = invoke_shielder_call(deployment, calldata, Some(amount));
 
@@ -66,7 +66,8 @@ mod tests {
     use shielder_account::ShielderAccount;
     use shielder_circuits::Fr;
     use shielder_contract::ShielderContract::{
-        depositCall, Deposit, ShielderContractErrors, ShielderContractEvents, WrongContractVersion,
+        depositNativeCall, Deposit, ShielderContractErrors, ShielderContractEvents,
+        WrongContractVersion,
     };
 
     use crate::{
@@ -263,10 +264,8 @@ mod tests {
     fn fails_if_merkle_root_does_not_exist(mut deployment: Deployment) {
         let mut shielder_account = ShielderAccount::default();
 
-        let calldata = depositCall {
+        let calldata = depositNativeCall {
             expectedContractVersion: FixedBytes([0, 1, 0]),
-            tokenAddress: Address::ZERO,
-            amount: U256::from(10),
             idHiding: U256::ZERO,
             oldNullifierHash: U256::ZERO,
             newNote: U256::ZERO,

--- a/crates/integration-tests/src/shielder/calls/new_account_native.rs
+++ b/crates/integration-tests/src/shielder/calls/new_account_native.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{TxHash, U256};
 use shielder_account::{call_data::NewAccountCallType, ShielderAccount};
-use shielder_contract::ShielderContract::{newAccountCall, ShielderContractErrors};
+use shielder_contract::ShielderContract::{newAccountNativeCall, ShielderContractErrors};
 
 use crate::shielder::{invoke_shielder_call, CallResult, Deployment};
 
@@ -8,7 +8,7 @@ pub fn prepare_call(
     deployment: &mut Deployment,
     shielder_account: &mut ShielderAccount,
     amount: U256,
-) -> newAccountCall {
+) -> newAccountNativeCall {
     let (params, pk) = deployment.new_account_proving_params.clone();
     shielder_account.prepare_call::<NewAccountCallType>(&params, &pk, amount, &())
 }
@@ -17,7 +17,7 @@ pub fn invoke_call(
     deployment: &mut Deployment,
     shielder_account: &mut ShielderAccount,
     amount: U256,
-    calldata: &newAccountCall,
+    calldata: &newAccountNativeCall,
 ) -> CallResult {
     let call_result = invoke_shielder_call(deployment, calldata, Some(amount));
 

--- a/crates/integration-tests/src/shielder/calls/withdraw_native.rs
+++ b/crates/integration-tests/src/shielder/calls/withdraw_native.rs
@@ -5,7 +5,7 @@ use shielder_account::{
     call_data::{MerkleProof, WithdrawCallType, WithdrawExtra},
     ShielderAccount,
 };
-use shielder_contract::ShielderContract::withdrawCall;
+use shielder_contract::ShielderContract::withdrawNativeCall;
 use shielder_setup::version::ContractVersion;
 
 use crate::shielder::{
@@ -35,7 +35,7 @@ pub fn prepare_call(
     deployment: &mut Deployment,
     shielder_account: &mut ShielderAccount,
     args: PrepareCallArgs,
-) -> (withdrawCall, U256) {
+) -> (withdrawNativeCall, U256) {
     let note_index = shielder_account
         .current_leaf_index()
         .expect("No leaf index");
@@ -73,7 +73,7 @@ pub fn prepare_call(
 pub fn invoke_call(
     deployment: &mut Deployment,
     shielder_account: &mut ShielderAccount,
-    calldata: &withdrawCall,
+    calldata: &withdrawNativeCall,
 ) -> CallResult {
     let call_result = invoke_shielder_call(deployment, calldata, None);
 
@@ -100,7 +100,7 @@ mod tests {
     use shielder_account::ShielderAccount;
     use shielder_circuits::Fr;
     use shielder_contract::ShielderContract::{
-        withdrawCall, ShielderContractErrors, ShielderContractEvents, Withdraw,
+        withdrawNativeCall, ShielderContractErrors, ShielderContractEvents, Withdraw,
         WrongContractVersion,
     };
 
@@ -351,9 +351,8 @@ mod tests {
     fn fails_if_incorrect_expected_version(mut deployment: Deployment) {
         let mut shielder_account = ShielderAccount::default();
 
-        let calldata = withdrawCall {
+        let calldata = withdrawNativeCall {
             expectedContractVersion: FixedBytes([9, 8, 7]),
-            tokenAddress: Address::ZERO,
             idHiding: U256::ZERO,
             withdrawalAddress: Address::from_str(RECIPIENT_ADDRESS).unwrap(),
             relayerAddress: Address::from_str(RELAYER_ADDRESS).unwrap(),
@@ -383,9 +382,8 @@ mod tests {
     fn fails_if_merkle_root_does_not_exist(mut deployment: Deployment) {
         let mut shielder_account = ShielderAccount::default();
 
-        let calldata = withdrawCall {
+        let calldata = withdrawNativeCall {
             expectedContractVersion: FixedBytes([0, 1, 0]),
-            tokenAddress: Address::ZERO,
             idHiding: U256::ZERO,
             withdrawalAddress: Address::from_str(RECIPIENT_ADDRESS).unwrap(),
             relayerAddress: Address::from_str(RELAYER_ADDRESS).unwrap(),

--- a/crates/shielder-account/src/call_data.rs
+++ b/crates/shielder-account/src/call_data.rs
@@ -9,7 +9,7 @@ use shielder_circuits::{
     Field, Fr, ProverKnowledge, PublicInputProvider,
 };
 use shielder_contract::{
-    ShielderContract::{depositCall, newAccountCall, withdrawCall},
+    ShielderContract::{depositNativeCall, newAccountNativeCall, withdrawNativeCall},
     WithdrawCommitment,
 };
 use shielder_setup::version::{contract_version, ContractVersion};
@@ -55,7 +55,7 @@ pub enum NewAccountCallType {}
 impl CallType for NewAccountCallType {
     type Extra = ();
     type ProverKnowledge = NewAccountProverKnowledge<Fr>;
-    type Calldata = newAccountCall;
+    type Calldata = newAccountNativeCall;
 
     fn prepare_prover_knowledge(
         account: &ShielderAccount,
@@ -76,10 +76,8 @@ impl CallType for NewAccountCallType {
         _: &Self::Extra,
     ) -> Self::Calldata {
         use shielder_circuits::circuits::new_account::NewAccountInstance::*;
-        newAccountCall {
+        newAccountNativeCall {
             expectedContractVersion: contract_version().to_bytes(),
-            tokenAddress: Address::ZERO,
-            amount: field_to_u256(prover_knowledge.compute_public_input(InitialDeposit)),
             newNote: field_to_u256(prover_knowledge.compute_public_input(HashedNote)),
             idHash: field_to_u256(prover_knowledge.compute_public_input(HashedId)),
             proof: Bytes::from(proof),
@@ -97,7 +95,7 @@ impl CallType for DepositCallType {
     type Extra = MerkleProof;
     type ProverKnowledge = DepositProverKnowledge<Fr>;
 
-    type Calldata = depositCall;
+    type Calldata = depositNativeCall;
 
     fn prepare_prover_knowledge(
         account: &ShielderAccount,
@@ -133,10 +131,8 @@ impl CallType for DepositCallType {
         _: &Self::Extra,
     ) -> Self::Calldata {
         use shielder_circuits::circuits::deposit::DepositInstance::*;
-        depositCall {
+        depositNativeCall {
             expectedContractVersion: contract_version().to_bytes(),
-            tokenAddress: Address::ZERO,
-            amount: field_to_u256(pk.compute_public_input(DepositValue)),
             idHiding: field_to_u256(pk.compute_public_input(IdHiding)),
             oldNullifierHash: field_to_u256(pk.compute_public_input(HashedOldNullifier)),
             newNote: field_to_u256(pk.compute_public_input(HashedNewNote)),
@@ -158,7 +154,7 @@ pub enum WithdrawCallType {}
 impl CallType for WithdrawCallType {
     type Extra = WithdrawExtra;
     type ProverKnowledge = WithdrawProverKnowledge<Fr>;
-    type Calldata = withdrawCall;
+    type Calldata = withdrawNativeCall;
 
     fn prepare_prover_knowledge(
         account: &ShielderAccount,
@@ -202,10 +198,9 @@ impl CallType for WithdrawCallType {
         extra: &Self::Extra,
     ) -> Self::Calldata {
         use shielder_circuits::circuits::withdraw::WithdrawInstance::*;
-        withdrawCall {
+        withdrawNativeCall {
             expectedContractVersion: contract_version().to_bytes(),
             idHiding: field_to_u256(pk.compute_public_input(IdHiding)),
-            tokenAddress: Address::ZERO,
             amount: field_to_u256(pk.compute_public_input(WithdrawalValue)),
             withdrawalAddress: extra.to,
             merkleRoot: field_to_u256(pk.compute_public_input(MerkleRoot)),

--- a/crates/shielder-cli/src/recovery.rs
+++ b/crates/shielder-cli/src/recovery.rs
@@ -13,8 +13,8 @@ use shielder_contract::{
     events::get_event,
     providers::create_simple_provider,
     ShielderContract::{
-        depositCall, newAccountCall, withdrawCall, Deposit, NewAccount, ShielderContractEvents,
-        Withdraw,
+        depositNativeCall, newAccountNativeCall, withdrawNativeCall, Deposit, NewAccount,
+        ShielderContractEvents, Withdraw,
     },
 };
 use tracing::{error, info};
@@ -117,13 +117,13 @@ async fn try_get_shielder_event_for_tx(
     block_hash: BlockHash,
 ) -> Result<Option<ShielderContractEvents>> {
     let tx_data = tx.input();
-    let maybe_action = if newAccountCall::abi_decode(tx_data, true).is_ok() {
+    let maybe_action = if newAccountNativeCall::abi_decode(tx_data, true).is_ok() {
         let event = get_event::<NewAccount>(provider, tx.tx_hash(), block_hash).await?;
         Some(ShielderContractEvents::NewAccount(event))
-    } else if depositCall::abi_decode(tx_data, true).is_ok() {
+    } else if depositNativeCall::abi_decode(tx_data, true).is_ok() {
         let event = get_event::<Deposit>(provider, tx.tx_hash(), block_hash).await?;
         Some(ShielderContractEvents::Deposit(event))
-    } else if withdrawCall::abi_decode(tx_data, true).is_ok() {
+    } else if withdrawNativeCall::abi_decode(tx_data, true).is_ok() {
         let event = get_event::<Withdraw>(provider, tx.tx_hash(), block_hash).await?;
         Some(ShielderContractEvents::Withdraw(event))
     } else {

--- a/crates/shielder-contract/src/api.rs
+++ b/crates/shielder-contract/src/api.rs
@@ -7,8 +7,8 @@ use crate::{
     connection::{Connection, ConnectionPolicy, NoProvider},
     ContractResult,
     ShielderContract::{
-        anonymityRevokerPubkeyCall, depositNativeCall, getMerklePathCall,
-        newAccountNativeCall, nullifiersCall, withdrawNativeCall,
+        anonymityRevokerPubkeyCall, depositNativeCall, getMerklePathCall, newAccountNativeCall,
+        nullifiersCall, withdrawNativeCall,
     },
 };
 

--- a/crates/shielder-contract/src/api.rs
+++ b/crates/shielder-contract/src/api.rs
@@ -7,7 +7,8 @@ use crate::{
     connection::{Connection, ConnectionPolicy, NoProvider},
     ContractResult,
     ShielderContract::{
-        depositCall, getMerklePathCall, newAccountCall, nullifiersCall, withdrawCall,
+        depositNativeCall, getMerklePathCall, newAccountNativeCall, nullifiersCall,
+        withdrawNativeCall,
     },
 };
 
@@ -34,27 +35,27 @@ impl<P: Provider + Clone> ShielderUser<P> {
     }
 
     /// Create new account.
-    pub async fn create_new_account_native<C: CallType<newAccountCall>>(
+    pub async fn create_new_account_native<C: CallType<newAccountNativeCall>>(
         &self,
-        call: newAccountCall,
+        call: newAccountNativeCall,
         value: U256,
     ) -> ContractResult<C::Result> {
         self.connection.call_with_value::<C, _>(call, value).await
     }
 
     /// Deposit native currency into the contract.
-    pub async fn deposit_native<C: CallType<depositCall>>(
+    pub async fn deposit_native<C: CallType<depositNativeCall>>(
         &self,
-        call: depositCall,
+        call: depositNativeCall,
         value: U256,
     ) -> ContractResult<C::Result> {
         self.connection.call_with_value::<C, _>(call, value).await
     }
 
     /// Withdraw native currency from the contract.
-    pub async fn withdraw_native<C: CallType<withdrawCall>>(
+    pub async fn withdraw_native<C: CallType<withdrawNativeCall>>(
         &self,
-        call: withdrawCall,
+        call: withdrawNativeCall,
     ) -> ContractResult<C::Result> {
         self.connection.call::<C, _>(call).await
     }

--- a/crates/shielder-contract/src/types.rs
+++ b/crates/shielder-contract/src/types.rs
@@ -76,6 +76,7 @@ sol! {
             bytes3 expectedContractVersion,
             uint256 newNote,
             uint256 idHash,
+            uint256 symKeyEncryption,
             bytes calldata proof
         ) external payable whenNotPaused;
         function newAccountERC20(

--- a/crates/shielder-contract/src/types.rs
+++ b/crates/shielder-contract/src/types.rs
@@ -48,7 +48,6 @@ sol! {
         error FeeHigherThanAmount();
         error MerkleRootDoesNotExist();
         error NativeTransferFailed();
-        error SafeERC20FailedOperation(address token);
         error WithdrawVerificationFailed();
         error NewAccountVerificationFailed();
         error ZeroAmount();

--- a/crates/shielder-relayer/src/relay/mod.rs
+++ b/crates/shielder-relayer/src/relay/mod.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use shielder_contract::{
     alloy_primitives::{Address, U256},
-    ShielderContract::withdrawCall,
+    ShielderContract::withdrawNativeCall,
 };
 use shielder_relayer::{server_error, FeeToken, RelayQuery, RelayResponse, SimpleServiceResponse};
 use shielder_setup::version::{contract_version, ContractVersion};
@@ -74,11 +74,10 @@ fn bad_request(msg: &str) -> Response {
     (StatusCode::BAD_REQUEST, SimpleServiceResponse::from(msg)).into_response()
 }
 
-fn create_call(q: RelayQuery, relayer_address: Address, relayer_fee: U256) -> withdrawCall {
-    withdrawCall {
+fn create_call(q: RelayQuery, relayer_address: Address, relayer_fee: U256) -> withdrawNativeCall {
+    withdrawNativeCall {
         expectedContractVersion: q.expected_contract_version,
         idHiding: q.id_hiding,
-        tokenAddress: Address::ZERO,
         withdrawalAddress: q.withdraw_address,
         relayerAddress: relayer_address,
         relayerFee: relayer_fee,

--- a/crates/shielder-relayer/src/relay/taskmaster.rs
+++ b/crates/shielder-relayer/src/relay/taskmaster.rs
@@ -4,7 +4,7 @@ use async_channel::{Receiver as MPMCReceiver, Sender as MPMCSender};
 use shielder_contract::{
     alloy_primitives::{Address, TxHash},
     call_type::{DryRun, Submit},
-    ShielderContract::withdrawCall,
+    ShielderContract::withdrawNativeCall,
     ShielderContractError, ShielderUser,
 };
 use tokio::sync::{
@@ -31,7 +31,7 @@ pub enum TaskResult {
 
 pub struct Task {
     report: OneshotSender<(RequestTrace, TaskResult)>,
-    payload: withdrawCall,
+    payload: withdrawNativeCall,
     request_trace: RequestTrace,
 }
 
@@ -90,7 +90,7 @@ impl Taskmaster {
 
     pub async fn register_new_task(
         &self,
-        payload: withdrawCall,
+        payload: withdrawNativeCall,
         mut request_trace: RequestTrace,
     ) -> Result<OneshotReceiver<(RequestTrace, TaskResult)>> {
         let (report_sender, report_receiver) = oneshot::channel();

--- a/crates/shielder-relayer/test-resources/AcceptingShielder.sol
+++ b/crates/shielder-relayer/test-resources/AcceptingShielder.sol
@@ -3,10 +3,9 @@
 pragma solidity ^0.8.20;
 
 contract AcceptingShielder {
-    function withdraw(
+    function withdrawNative(
         bytes3 expectedContractVersion,
         uint256 idHiding,
-        address tokenAddress,
         uint256 amount,
         address withdrawalAddress,
         uint256 merkleRoot,

--- a/crates/shielder-relayer/test-resources/RevertingShielder.sol
+++ b/crates/shielder-relayer/test-resources/RevertingShielder.sol
@@ -3,10 +3,9 @@
 pragma solidity ^0.8.20;
 
 contract RevertingShielder {
-    function withdraw(
+    function withdrawNative(
         bytes3 expectedContractVersion,
         uint256 idHiding,
-        address tokenAddress,
         uint256 amount,
         address withdrawalAddress,
         uint256 merkleRoot,

--- a/crates/stress-testing/src/actor.rs
+++ b/crates/stress-testing/src/actor.rs
@@ -5,7 +5,7 @@ use shielder_circuits::circuits::{Params, ProvingKey};
 use shielder_contract::{
     alloy_primitives::{Address, U256},
     ConnectionPolicy,
-    ShielderContract::newAccountCall,
+    ShielderContract::newAccountNativeCall,
     ShielderUser,
 };
 
@@ -37,7 +37,7 @@ impl Actor {
         params: &Params,
         pk: &ProvingKey,
         amount: U256,
-    ) -> newAccountCall {
+    ) -> newAccountNativeCall {
         self.account
             .prepare_call::<NewAccountCallType>(params, pk, amount, &())
     }

--- a/ts/shielder-sdk/src/chain/contract.ts
+++ b/ts/shielder-sdk/src/chain/contract.ts
@@ -125,7 +125,7 @@ export class Contract implements IContract {
     proof: Uint8Array
   ) => {
     await handleWrongContractVersionError(() => {
-      return this.contract.simulate.newAccount(
+      return this.contract.simulate.newAccountNative(
         [
           expectedContractVersion,
           zeroAddress,
@@ -140,7 +140,7 @@ export class Contract implements IContract {
     });
     return encodeFunctionData({
       abi,
-      functionName: "newAccount",
+      functionName: "newAccountNative",
       args: [
         expectedContractVersion,
         zeroAddress,
@@ -164,7 +164,7 @@ export class Contract implements IContract {
     proof: Uint8Array
   ) => {
     await handleWrongContractVersionError(() => {
-      return this.contract.simulate.deposit(
+      return this.contract.simulate.depositNative(
         [
           expectedContractVersion,
           zeroAddress,
@@ -180,7 +180,7 @@ export class Contract implements IContract {
     });
     return encodeFunctionData({
       abi,
-      functionName: "deposit",
+      functionName: "depositNative",
       args: [
         expectedContractVersion,
         zeroAddress,

--- a/ts/shielder-sdk/src/chain/contract.ts
+++ b/ts/shielder-sdk/src/chain/contract.ts
@@ -128,7 +128,6 @@ export class Contract implements IContract {
       return this.contract.simulate.newAccountNative(
         [
           expectedContractVersion,
-          amount,
           newNote,
           idHash,
           symKeyEncryption,
@@ -142,7 +141,6 @@ export class Contract implements IContract {
       functionName: "newAccountNative",
       args: [
         expectedContractVersion,
-        amount,
         newNote,
         idHash,
         symKeyEncryption,
@@ -165,7 +163,6 @@ export class Contract implements IContract {
       return this.contract.simulate.depositNative(
         [
           expectedContractVersion,
-          amount,
           idHiding,
           oldNoteNullifierHash,
           newNote,
@@ -180,7 +177,6 @@ export class Contract implements IContract {
       functionName: "depositNative",
       args: [
         expectedContractVersion,
-        amount,
         idHiding,
         oldNoteNullifierHash,
         newNote,

--- a/ts/shielder-sdk/src/chain/contract.ts
+++ b/ts/shielder-sdk/src/chain/contract.ts
@@ -128,7 +128,6 @@ export class Contract implements IContract {
       return this.contract.simulate.newAccountNative(
         [
           expectedContractVersion,
-          zeroAddress,
           amount,
           newNote,
           idHash,
@@ -143,7 +142,6 @@ export class Contract implements IContract {
       functionName: "newAccountNative",
       args: [
         expectedContractVersion,
-        zeroAddress,
         amount,
         newNote,
         idHash,
@@ -167,7 +165,6 @@ export class Contract implements IContract {
       return this.contract.simulate.depositNative(
         [
           expectedContractVersion,
-          zeroAddress,
           amount,
           idHiding,
           oldNoteNullifierHash,
@@ -183,7 +180,6 @@ export class Contract implements IContract {
       functionName: "depositNative",
       args: [
         expectedContractVersion,
-        zeroAddress,
         amount,
         idHiding,
         oldNoteNullifierHash,

--- a/ts/shielder-sdk/src/chain/contract.ts
+++ b/ts/shielder-sdk/src/chain/contract.ts
@@ -6,8 +6,7 @@ import {
   getContract,
   GetContractReturnType,
   Hash,
-  PublicClient,
-  zeroAddress
+  PublicClient
 } from "viem";
 import { BaseError, ContractFunctionRevertedError } from "viem";
 


### PR DESCRIPTION
Actually partially reusing some code @kroist wrote earlier.

Not using `trySafeTransfer` as @fbielejec suggested, because it is a very recent OpenZeppelin feature, not present in the newest 5.2.0 release.

Also making small fixes to the `gas-consumption` workflow: naming and making sure the binary is rebuilt in both branches, so that in can talk to the contract even if it changes.

I will add tests in subsequent PRs.