### PR TITLE
small fixes for shielder-sdk

### DIFF
--- a/ts/shielder-sdk-crypto-wasm/src/hasher.ts
+++ b/ts/shielder-sdk-crypto-wasm/src/hasher.ts
@@ -29,7 +29,9 @@ export class Hasher extends WasmClientModuleBase implements IHasher {
   }
 
   poseidonRate(): Promise<number> {
-    // TODO: implement when wasm module has this function
-    throw new Error("Method not implemented.");
+    if (!this.wasmModule) {
+      throw new Error("Wasm module not initialized");
+    }
+    return Promise.resolve(this.wasmModule.poseidon_rate());
   }
 }

--- a/ts/shielder-sdk/__tests/actions/withdraw.test.ts
+++ b/ts/shielder-sdk/__tests/actions/withdraw.test.ts
@@ -19,7 +19,7 @@ import {
   WithdrawResponse
 } from "../../src/chain/relayer";
 import { encodePacked, hexToBigInt, keccak256 } from "viem";
-import { nativeToken } from "../../src/types";
+import { nativeToken, Token } from "../../src/types";
 
 const nativeTokenAddress = "0x0000000000000000000000000000000000000000";
 
@@ -330,13 +330,16 @@ describe("WithdrawAction", () => {
 
       expect(relayer.withdraw).toHaveBeenCalledWith(
         expectedVersion,
+        nativeToken(),
         scalarToBigint(calldata.calldata.pubInputs.idHiding),
         scalarToBigint(calldata.calldata.pubInputs.hNullifierOld),
         scalarToBigint(calldata.calldata.pubInputs.hNoteNew),
         scalarToBigint(calldata.calldata.pubInputs.merkleRoot),
         calldata.amount,
         calldata.calldata.proof,
-        mockAddress
+        mockAddress,
+        scalarToBigint(calldata.calldata.pubInputs.macSalt),
+        scalarToBigint(calldata.calldata.pubInputs.macCommitment)
       );
 
       expect(txHash).toBe("0xtxHash");
@@ -360,13 +363,16 @@ describe("WithdrawAction", () => {
         .fn<
           (
             expectedContractVersion: `0x${string}`,
+            token: Token,
             idHiding: bigint,
             oldNullifierHash: bigint,
             newNote: bigint,
             merkleRoot: bigint,
             amount: bigint,
             proof: Uint8Array,
-            withdrawAddress: `0x${string}`
+            withdrawalAddress: `0x${string}`,
+            macSalt: bigint,
+            macCommitment: bigint
           ) => Promise<WithdrawResponse>
         >()
         .mockRejectedValue(mockedErr);
@@ -392,13 +398,16 @@ describe("WithdrawAction", () => {
         .fn<
           (
             expectedContractVersion: `0x${string}`,
+            token: Token,
             idHiding: bigint,
             oldNullifierHash: bigint,
             newNote: bigint,
             merkleRoot: bigint,
             amount: bigint,
             proof: Uint8Array,
-            withdrawAddress: `0x${string}`
+            withdrawalAddress: `0x${string}`,
+            macSalt: bigint,
+            macCommitment: bigint
           ) => Promise<WithdrawResponse>
         >()
         .mockRejectedValue(new Error("mocked contract rejection"));

--- a/ts/shielder-sdk/__tests/utils.test.ts
+++ b/ts/shielder-sdk/__tests/utils.test.ts
@@ -37,6 +37,6 @@ test("note version", () => {
 });
 
 test("isVersionSupported", () => {
-  expect(isVersionSupported("0x000001")).toBe(true);
+  expect(isVersionSupported("0x000100")).toBe(true);
   expect(isVersionSupported("0x000002")).toBe(false);
 });

--- a/ts/shielder-sdk/src/chain/contract.ts
+++ b/ts/shielder-sdk/src/chain/contract.ts
@@ -51,6 +51,7 @@ export type NoteEvent = {
   newNote: bigint;
   txHash: Hash;
   to?: Address;
+  relayerFee?: bigint;
   block: bigint;
 };
 
@@ -359,6 +360,10 @@ export class Contract implements IContract {
         to:
           event.eventName === "Withdraw"
             ? (event.args.withdrawalAddress as Address)
+            : undefined,
+        relayerFee:
+          event.eventName === "Withdraw"
+            ? (event.args.fee as bigint)
             : undefined
       } as NoteEvent;
     });

--- a/ts/shielder-sdk/src/constants.ts
+++ b/ts/shielder-sdk/src/constants.ts
@@ -4,7 +4,7 @@ export const chainNativeCurrency = {
   symbol: "AZERO",
   decimals: 18
 };
-export const contractVersion = "0x000001";
+export const contractVersion = "0x000100";
 export const relayPath = "/relay";
 export const feePath = "/quote_fees";
 export const feeAddressPath = "/fee_address";

--- a/ts/shielder-sdk/src/index.ts
+++ b/ts/shielder-sdk/src/index.ts
@@ -13,6 +13,7 @@ export {
   type ERC20Token,
   type NativeToken,
   type Token,
-  nativeToken
+  nativeToken,
+  erc20Token
 } from "@/types";
 export { shieldActionGasLimit } from "@/constants";

--- a/ts/shielder-sdk/src/state/sync.ts
+++ b/ts/shielder-sdk/src/state/sync.ts
@@ -148,6 +148,7 @@ const eventToTransaction = (event: NoteEvent): ShielderTransaction => {
     type: event.name,
     amount: event.amount,
     to: event.to,
+    relayerFee: event.relayerFee,
     txHash: event.txHash,
     block: event.block
   };

--- a/ts/shielder-sdk/src/state/types.ts
+++ b/ts/shielder-sdk/src/state/types.ts
@@ -37,6 +37,7 @@ export type ShielderTransaction = {
   type: "NewAccount" | "Deposit" | "Withdraw";
   amount: bigint;
   to?: Address;
+  relayerFee?: bigint;
   txHash: Hex;
   block: bigint;
 };

--- a/ts/shielder-sdk/src/types.ts
+++ b/ts/shielder-sdk/src/types.ts
@@ -13,6 +13,6 @@ export function nativeToken(): NativeToken {
   return { type: "native" };
 }
 
-export function ERC20Token(address: `0x${string}`): ERC20Token {
+export function erc20Token(address: `0x${string}`): ERC20Token {
   return { type: "erc20", address };
 }


### PR DESCRIPTION
includes:
- use `poseidonRate` binding
- adapt relayer call to current relayer implementation
- include relayer fee in transaction history
- some renamings
- fixes unit test for `sync.ts`