### PR TITLE
Generic types in `shielder-sdk-crypto`

### DIFF
--- a/ts/shielder-sdk-crypto-wasm/src/circuits/deposit.ts
+++ b/ts/shielder-sdk-crypto-wasm/src/circuits/deposit.ts
@@ -25,7 +25,7 @@ export class DepositCircuit
     this.wasmCircuit = new this.wasmModule.DepositCircuit();
   }
 
-  prove(values: DepositAdvice): Promise<Proof> {
+  prove(values: DepositAdvice<Scalar>): Promise<Proof> {
     if (!this.wasmCircuit) {
       throw new Error("Circuit not initialized");
     }
@@ -46,7 +46,9 @@ export class DepositCircuit
     );
   }
 
-  async pubInputs(values: DepositAdvice): Promise<DepositPubInputs> {
+  async pubInputs(
+    values: DepositAdvice<Scalar>
+  ): Promise<DepositPubInputs<Scalar>> {
     if (!this.wasmCircuit) {
       throw new Error("Circuit not initialized");
     }
@@ -78,7 +80,10 @@ export class DepositCircuit
     });
   }
 
-  async verify(proof: Proof, pubInputs: DepositPubInputs): Promise<boolean> {
+  async verify(
+    proof: Proof,
+    pubInputs: DepositPubInputs<Scalar>
+  ): Promise<boolean> {
     if (!this.wasmCircuit) {
       throw new Error("Circuit not initialized");
     }

--- a/ts/shielder-sdk-crypto-wasm/src/circuits/newAccount.ts
+++ b/ts/shielder-sdk-crypto-wasm/src/circuits/newAccount.ts
@@ -26,7 +26,7 @@ export class NewAccountCircuit
     this.wasmCircuit = new this.wasmModule.NewAccountCircuit();
   }
 
-  prove(values: NewAccountAdvice): Promise<Proof> {
+  prove(values: NewAccountAdvice<Scalar>): Promise<Proof> {
     if (!this.wasmCircuit) {
       throw new Error("Circuit not initialized");
     }
@@ -38,13 +38,15 @@ export class NewAccountCircuit
         values.initialDeposit.bytes,
         values.tokenAddress.bytes,
         values.encryptionSalt.bytes,
-        values.anonymityRevokerPubkey.x.bytes,
-        values.anonymityRevokerPubkey.y.bytes
+        values.anonymityRevokerPublicKeyX.bytes,
+        values.anonymityRevokerPublicKeyY.bytes
       )
     );
   }
 
-  async pubInputs(values: NewAccountAdvice): Promise<NewAccountPubInputs> {
+  async pubInputs(
+    values: NewAccountAdvice<Scalar>
+  ): Promise<NewAccountPubInputs<Scalar>> {
     if (!this.wasmCircuit) {
       throw new Error("Circuit not initialized");
     }
@@ -58,8 +60,8 @@ export class NewAccountCircuit
       values.initialDeposit.bytes,
       values.tokenAddress.bytes,
       values.encryptionSalt.bytes,
-      values.anonymityRevokerPubkey.x.bytes,
-      values.anonymityRevokerPubkey.y.bytes
+      values.anonymityRevokerPublicKeyX.bytes,
+      values.anonymityRevokerPublicKeyY.bytes
     );
 
     return Promise.resolve({
@@ -67,22 +69,23 @@ export class NewAccountCircuit
       hId: new Scalar(pubInputsBytes.hashed_id),
       initialDeposit: new Scalar(pubInputsBytes.initial_deposit),
       tokenAddress: new Scalar(pubInputsBytes.token_address),
-      anonymityRevokerPubkey: {
-        x: new Scalar(pubInputsBytes.anonymity_revoker_public_key_x),
-        y: new Scalar(pubInputsBytes.anonymity_revoker_public_key_y)
-      },
-      symKeyEncryption1: {
-        x: new Scalar(pubInputsBytes.sym_key_encryption_1_x),
-        y: new Scalar(pubInputsBytes.sym_key_encryption_1_y)
-      },
-      symKeyEncryption2: {
-        x: new Scalar(pubInputsBytes.sym_key_encryption_2_x),
-        y: new Scalar(pubInputsBytes.sym_key_encryption_2_y)
-      }
+      anonymityRevokerPublicKeyX: new Scalar(
+        pubInputsBytes.anonymity_revoker_public_key_x
+      ),
+      anonymityRevokerPublicKeyY: new Scalar(
+        pubInputsBytes.anonymity_revoker_public_key_y
+      ),
+      symKeyEncryption1X: new Scalar(pubInputsBytes.sym_key_encryption_1_x),
+      symKeyEncryption1Y: new Scalar(pubInputsBytes.sym_key_encryption_1_y),
+      symKeyEncryption2X: new Scalar(pubInputsBytes.sym_key_encryption_2_x),
+      symKeyEncryption2Y: new Scalar(pubInputsBytes.sym_key_encryption_2_y)
     });
   }
 
-  async verify(proof: Proof, pubInputs: NewAccountPubInputs): Promise<boolean> {
+  async verify(
+    proof: Proof,
+    pubInputs: NewAccountPubInputs<Scalar>
+  ): Promise<boolean> {
     if (!this.wasmCircuit) {
       throw new Error("Circuit not initialized");
     }
@@ -94,12 +97,12 @@ export class NewAccountCircuit
           pubInputs.hId.bytes,
           pubInputs.initialDeposit.bytes,
           pubInputs.tokenAddress.bytes,
-          pubInputs.anonymityRevokerPubkey.x.bytes,
-          pubInputs.anonymityRevokerPubkey.y.bytes,
-          pubInputs.symKeyEncryption1.x.bytes,
-          pubInputs.symKeyEncryption1.y.bytes,
-          pubInputs.symKeyEncryption2.x.bytes,
-          pubInputs.symKeyEncryption2.y.bytes,
+          pubInputs.anonymityRevokerPublicKeyX.bytes,
+          pubInputs.anonymityRevokerPublicKeyY.bytes,
+          pubInputs.symKeyEncryption1X.bytes,
+          pubInputs.symKeyEncryption1Y.bytes,
+          pubInputs.symKeyEncryption2X.bytes,
+          pubInputs.symKeyEncryption2Y.bytes,
           proof
         )
       );

--- a/ts/shielder-sdk-crypto-wasm/src/circuits/withdraw.ts
+++ b/ts/shielder-sdk-crypto-wasm/src/circuits/withdraw.ts
@@ -25,7 +25,7 @@ export class WithdrawCircuit
     this.wasmCircuit = new this.wasmModule.WithdrawCircuit();
   }
 
-  prove(values: WithdrawAdvice): Promise<Proof> {
+  prove(values: WithdrawAdvice<Scalar>): Promise<Proof> {
     if (!this.wasmCircuit) {
       throw new Error("Circuit not initialized");
     }
@@ -47,7 +47,9 @@ export class WithdrawCircuit
     );
   }
 
-  async pubInputs(values: WithdrawAdvice): Promise<WithdrawPubInputs> {
+  async pubInputs(
+    values: WithdrawAdvice<Scalar>
+  ): Promise<WithdrawPubInputs<Scalar>> {
     if (!this.wasmCircuit) {
       throw new Error("Circuit not initialized");
     }
@@ -82,7 +84,10 @@ export class WithdrawCircuit
     });
   }
 
-  async verify(proof: Proof, pubInputs: WithdrawPubInputs): Promise<boolean> {
+  async verify(
+    proof: Proof,
+    pubInputs: WithdrawPubInputs<Scalar>
+  ): Promise<boolean> {
     if (!this.wasmCircuit) {
       throw new Error("Circuit not initialized");
     }

--- a/ts/shielder-sdk-crypto-wasm/src/secretGenerator.ts
+++ b/ts/shielder-sdk-crypto-wasm/src/secretGenerator.ts
@@ -14,7 +14,10 @@ export class SecretGenerator
     super.init(caller);
   }
 
-  getSecrets(id: Scalar, nonce: number): Promise<ShielderActionSecrets> {
+  getSecrets(
+    id: Scalar,
+    nonce: number
+  ): Promise<ShielderActionSecrets<Scalar>> {
     if (!this.wasmModule) {
       throw new Error("Wasm module not initialized");
     }

--- a/ts/shielder-sdk-crypto/src/cryptoClient.ts
+++ b/ts/shielder-sdk-crypto/src/cryptoClient.ts
@@ -11,21 +11,26 @@ import {
 } from "./types";
 
 export interface NewAccountCircuit {
-  prove(values: NewAccountAdvice): Promise<Proof>;
-  pubInputs(values: NewAccountAdvice): Promise<NewAccountPubInputs>;
-  verify(proof: Proof, pubInputs: NewAccountPubInputs): Promise<boolean>;
+  prove(values: NewAccountAdvice<Scalar>): Promise<Proof>;
+  pubInputs(
+    values: NewAccountAdvice<Scalar>
+  ): Promise<NewAccountPubInputs<Scalar>>;
+  verify(
+    proof: Proof,
+    pubInputs: NewAccountPubInputs<Scalar>
+  ): Promise<boolean>;
 }
 
 export interface DepositCircuit {
-  prove(values: DepositAdvice): Promise<Proof>;
-  pubInputs(values: DepositAdvice): Promise<DepositPubInputs>;
-  verify(proof: Proof, pubInputs: DepositPubInputs): Promise<boolean>;
+  prove(values: DepositAdvice<Scalar>): Promise<Proof>;
+  pubInputs(values: DepositAdvice<Scalar>): Promise<DepositPubInputs<Scalar>>;
+  verify(proof: Proof, pubInputs: DepositPubInputs<Scalar>): Promise<boolean>;
 }
 
 export interface WithdrawCircuit {
-  prove(values: WithdrawAdvice): Promise<Proof>;
-  pubInputs(values: WithdrawAdvice): Promise<WithdrawPubInputs>;
-  verify(proof: Proof, pubInputs: WithdrawPubInputs): Promise<boolean>;
+  prove(values: WithdrawAdvice<Scalar>): Promise<Proof>;
+  pubInputs(values: WithdrawAdvice<Scalar>): Promise<WithdrawPubInputs<Scalar>>;
+  verify(proof: Proof, pubInputs: WithdrawPubInputs<Scalar>): Promise<boolean>;
 }
 
 export interface Hasher {
@@ -35,7 +40,7 @@ export interface Hasher {
 }
 
 export interface SecretManager {
-  getSecrets(id: Scalar, nonce: number): Promise<ShielderActionSecrets>;
+  getSecrets(id: Scalar, nonce: number): Promise<ShielderActionSecrets<Scalar>>;
   deriveId(
     privateKey: `0x${string}`,
     tokenAddress: `0x${string}`

--- a/ts/shielder-sdk-crypto/src/types.ts
+++ b/ts/shielder-sdk-crypto/src/types.ts
@@ -1,87 +1,85 @@
-import { Scalar } from "./scalar";
-
 export type Proof = Uint8Array;
-export type CurvePointAffine<T> = {
-  x: T;
-  y: T;
-};
 
 // follows the order in shielder-circuits::circuits::new_account
-export type NewAccountPubInputs = {
-  hNote: Scalar;
-  hId: Scalar;
-  initialDeposit: Scalar;
-  tokenAddress: Scalar;
-  anonymityRevokerPubkey: CurvePointAffine<Scalar>;
-  symKeyEncryption1: CurvePointAffine<Scalar>;
-  symKeyEncryption2: CurvePointAffine<Scalar>;
+export type NewAccountPubInputs<T> = {
+  hNote: T;
+  hId: T;
+  initialDeposit: T;
+  tokenAddress: T;
+  anonymityRevokerPublicKeyX: T;
+  anonymityRevokerPublicKeyY: T;
+  symKeyEncryption1X: T;
+  symKeyEncryption1Y: T;
+  symKeyEncryption2X: T;
+  symKeyEncryption2Y: T;
 };
 
-export type NewAccountAdvice = {
-  id: Scalar;
-  nullifier: Scalar;
-  trapdoor: Scalar;
-  initialDeposit: Scalar;
-  tokenAddress: Scalar;
-  encryptionSalt: Scalar;
-  anonymityRevokerPubkey: CurvePointAffine<Scalar>;
+export type NewAccountAdvice<T> = {
+  id: T;
+  nullifier: T;
+  trapdoor: T;
+  initialDeposit: T;
+  tokenAddress: T;
+  encryptionSalt: T;
+  anonymityRevokerPublicKeyX: T;
+  anonymityRevokerPublicKeyY: T;
 };
 
 // follows the order in shielder-circuits::circuits::deposit
-export type DepositPubInputs = {
-  idHiding: Scalar;
-  merkleRoot: Scalar;
-  hNullifierOld: Scalar;
-  hNoteNew: Scalar;
-  value: Scalar;
-  tokenAddress: Scalar;
-  macSalt: Scalar;
-  macCommitment: Scalar;
+export type DepositPubInputs<T> = {
+  idHiding: T;
+  merkleRoot: T;
+  hNullifierOld: T;
+  hNoteNew: T;
+  value: T;
+  tokenAddress: T;
+  macSalt: T;
+  macCommitment: T;
 };
 
-export type DepositAdvice = {
-  id: Scalar;
-  nonce: Scalar;
-  nullifierOld: Scalar;
-  trapdoorOld: Scalar;
-  accountBalanceOld: Scalar;
-  tokenAddress: Scalar;
+export type DepositAdvice<T> = {
+  id: T;
+  nonce: T;
+  nullifierOld: T;
+  trapdoorOld: T;
+  accountBalanceOld: T;
+  tokenAddress: T;
   path: Uint8Array;
-  value: Scalar;
-  nullifierNew: Scalar;
-  trapdoorNew: Scalar;
-  macSalt: Scalar;
+  value: T;
+  nullifierNew: T;
+  trapdoorNew: T;
+  macSalt: T;
 };
 
 // follows the order in shielder-circuits::circuits::withdraw
-export type WithdrawPubInputs = {
-  idHiding: Scalar;
-  merkleRoot: Scalar;
-  hNullifierOld: Scalar;
-  hNoteNew: Scalar;
-  value: Scalar;
-  tokenAddress: Scalar;
-  commitment: Scalar;
-  macSalt: Scalar;
-  macCommitment: Scalar;
+export type WithdrawPubInputs<T> = {
+  idHiding: T;
+  merkleRoot: T;
+  hNullifierOld: T;
+  hNoteNew: T;
+  value: T;
+  tokenAddress: T;
+  commitment: T;
+  macSalt: T;
+  macCommitment: T;
 };
 
-export type WithdrawAdvice = {
-  id: Scalar;
-  nonce: Scalar;
-  nullifierOld: Scalar;
-  trapdoorOld: Scalar;
-  accountBalanceOld: Scalar;
-  tokenAddress: Scalar;
+export type WithdrawAdvice<T> = {
+  id: T;
+  nonce: T;
+  nullifierOld: T;
+  trapdoorOld: T;
+  accountBalanceOld: T;
+  tokenAddress: T;
   path: Uint8Array;
-  value: Scalar;
-  nullifierNew: Scalar;
-  trapdoorNew: Scalar;
-  commitment: Scalar;
-  macSalt: Scalar;
+  value: T;
+  nullifierNew: T;
+  trapdoorNew: T;
+  commitment: T;
+  macSalt: T;
 };
 
-export type ShielderActionSecrets = {
-  nullifier: Scalar;
-  trapdoor: Scalar;
+export type ShielderActionSecrets<T> = {
+  nullifier: T;
+  trapdoor: T;
 };

--- a/ts/shielder-sdk/__tests/actions/newAccount.test.ts
+++ b/ts/shielder-sdk/__tests/actions/newAccount.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vitest } from "vitest";
 import {
-  CurvePointAffine,
   NewAccountAdvice,
   NewAccountPubInputs,
   Scalar,
@@ -16,12 +15,7 @@ import { IContract, VersionRejectedByContract } from "../../src/chain/contract";
 import { SendShielderTransaction } from "../../src/client";
 import { nativeToken } from "../../src/types";
 
-const nativeTokenAddress = "0x0000000000000000000000000000000000000000";
-
-const ANONYMITY_REVOKER_PUBKEY = {
-  x: 123n,
-  y: 456n
-};
+const ANONYMITY_REVOKER_PUBKEY = [123n, 456n];
 
 describe("NewAccountAction", () => {
   let cryptoClient: MockedCryptoClient;
@@ -122,7 +116,7 @@ describe("NewAccountAction", () => {
       const amount = 100n;
       const expectedVersion = "0xversion" as `0x${string}`;
       const mockProve = vitest
-        .fn<(values: NewAccountAdvice) => Promise<Uint8Array>>()
+        .fn<(values: NewAccountAdvice<Scalar>) => Promise<Uint8Array>>()
         .mockRejectedValue(new Error("mocked prove failure"));
       cryptoClient.newAccountCircuit.prove = mockProve;
 
@@ -140,7 +134,7 @@ describe("NewAccountAction", () => {
         .fn<
           (
             proof: Uint8Array,
-            pubInputs: NewAccountPubInputs
+            pubInputs: NewAccountPubInputs<Scalar>
           ) => Promise<boolean>
         >()
         .mockResolvedValue(false);
@@ -178,14 +172,10 @@ describe("NewAccountAction", () => {
         scalarToBigint(calldata.calldata.pubInputs.hNote),
         scalarToBigint(calldata.calldata.pubInputs.hId),
         amount,
-        {
-          x: scalarToBigint(calldata.calldata.pubInputs.symKeyEncryption1.x),
-          y: scalarToBigint(calldata.calldata.pubInputs.symKeyEncryption1.y)
-        },
-        {
-          x: scalarToBigint(calldata.calldata.pubInputs.symKeyEncryption2.x),
-          y: scalarToBigint(calldata.calldata.pubInputs.symKeyEncryption2.y)
-        },
+        scalarToBigint(calldata.calldata.pubInputs.symKeyEncryption1X),
+        scalarToBigint(calldata.calldata.pubInputs.symKeyEncryption1Y),
+        scalarToBigint(calldata.calldata.pubInputs.symKeyEncryption2X),
+        scalarToBigint(calldata.calldata.pubInputs.symKeyEncryption2Y),
         calldata.calldata.proof
       );
 
@@ -217,8 +207,10 @@ describe("NewAccountAction", () => {
             newNote: bigint,
             idHash: bigint,
             amount: bigint,
-            symKeyEncryption1: CurvePointAffine<bigint>,
-            symKeyEncryption2: CurvePointAffine<bigint>,
+            symKeyEncryption1X: bigint,
+            symKeyEncryption1Y: bigint,
+            symKeyEncryption2X: bigint,
+            symKeyEncryption2Y: bigint,
             proof: Uint8Array
           ) => Promise<`0x${string}`>
         >()

--- a/ts/shielder-sdk/__tests/actions/withdraw.test.ts
+++ b/ts/shielder-sdk/__tests/actions/withdraw.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vitest } from "vitest";
 import {
-  CryptoClient,
   Scalar,
   scalarsEqual,
   scalarToBigint,
@@ -225,7 +224,7 @@ describe("WithdrawAction", () => {
       const totalFee = 1n;
 
       cryptoClient.withdrawCircuit.prove = vitest
-        .fn<(values: WithdrawAdvice) => Promise<Uint8Array>>()
+        .fn<(values: WithdrawAdvice<Scalar>) => Promise<Uint8Array>>()
         .mockRejectedValue("error");
 
       await expect(
@@ -246,7 +245,10 @@ describe("WithdrawAction", () => {
 
       cryptoClient.withdrawCircuit.verify = vitest
         .fn<
-          (proof: Uint8Array, values: WithdrawPubInputs) => Promise<boolean>
+          (
+            proof: Uint8Array,
+            values: WithdrawPubInputs<Scalar>
+          ) => Promise<boolean>
         >()
         .mockResolvedValue(false);
 

--- a/ts/shielder-sdk/__tests/generate-coverage-report.js
+++ b/ts/shielder-sdk/__tests/generate-coverage-report.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const fs = require("fs");
-const path = require("path");
+import fs from "fs";
+import path from "path";
 
 function generateCoverageReport() {
   // Read the coverage summary JSON

--- a/ts/shielder-sdk/__tests/helpers.ts
+++ b/ts/shielder-sdk/__tests/helpers.ts
@@ -95,7 +95,10 @@ class MockedHasher implements Hasher {
 }
 
 class MockedSecretManager implements SecretManager {
-  async getSecrets(id: Scalar, nonce: number): Promise<ShielderActionSecrets> {
+  async getSecrets(
+    id: Scalar,
+    nonce: number
+  ): Promise<ShielderActionSecrets<Scalar>> {
     return {
       nullifier: await mockedHash([
         id,
@@ -139,42 +142,41 @@ class MockedNoteTreeConfig implements NoteTreeConfig {
 }
 
 class MockedNewAccountCircuit implements NewAccountCircuit {
-  prove(values: NewAccountAdvice): Promise<Proof> {
+  prove(values: NewAccountAdvice<Scalar>): Promise<Proof> {
     return Promise.resolve(new Uint8Array());
   }
 
-  pubInputs(values: NewAccountAdvice): Promise<NewAccountPubInputs> {
+  pubInputs(
+    values: NewAccountAdvice<Scalar>
+  ): Promise<NewAccountPubInputs<Scalar>> {
     return Promise.resolve({
       hNote: Scalar.fromBigint(0n),
       hId: Scalar.fromBigint(0n),
       initialDeposit: Scalar.fromBigint(0n),
       tokenAddress: Scalar.fromBigint(0n),
-      anonymityRevokerPubkey: {
-        x: Scalar.fromBigint(0n),
-        y: Scalar.fromBigint(0n)
-      },
-      symKeyEncryption1: {
-        x: Scalar.fromBigint(0n),
-        y: Scalar.fromBigint(0n)
-      },
-      symKeyEncryption2: {
-        x: Scalar.fromBigint(0n),
-        y: Scalar.fromBigint(0n)
-      }
+      anonymityRevokerPublicKeyX: Scalar.fromBigint(0n),
+      anonymityRevokerPublicKeyY: Scalar.fromBigint(0n),
+      symKeyEncryption1X: Scalar.fromBigint(0n),
+      symKeyEncryption1Y: Scalar.fromBigint(0n),
+      symKeyEncryption2X: Scalar.fromBigint(0n),
+      symKeyEncryption2Y: Scalar.fromBigint(0n)
     });
   }
 
-  async verify(proof: Proof, pubInputs: NewAccountPubInputs): Promise<boolean> {
+  async verify(
+    proof: Proof,
+    pubInputs: NewAccountPubInputs<Scalar>
+  ): Promise<boolean> {
     return Promise.resolve(true);
   }
 }
 
 class MockedDepositCircuit implements DepositCircuit {
-  prove(values: DepositAdvice): Promise<Proof> {
+  prove(values: DepositAdvice<Scalar>): Promise<Proof> {
     return Promise.resolve(new Uint8Array());
   }
 
-  pubInputs(values: DepositAdvice): Promise<DepositPubInputs> {
+  pubInputs(values: DepositAdvice<Scalar>): Promise<DepositPubInputs<Scalar>> {
     return Promise.resolve({
       idHiding: Scalar.fromBigint(0n),
       merkleRoot: Scalar.fromBigint(0n),
@@ -187,7 +189,10 @@ class MockedDepositCircuit implements DepositCircuit {
     });
   }
 
-  async verify(proof: Proof, pubInputs: DepositPubInputs): Promise<boolean> {
+  async verify(
+    proof: Proof,
+    pubInputs: DepositPubInputs<Scalar>
+  ): Promise<boolean> {
     return Promise.resolve(true);
   }
 }
@@ -197,7 +202,9 @@ class MockedWithdrawCircuit implements WithdrawCircuit {
     return Promise.resolve(new Uint8Array());
   }
 
-  pubInputs(values: WithdrawAdvice): Promise<WithdrawPubInputs> {
+  pubInputs(
+    values: WithdrawAdvice<Scalar>
+  ): Promise<WithdrawPubInputs<Scalar>> {
     return Promise.resolve({
       idHiding: Scalar.fromBigint(0n),
       merkleRoot: Scalar.fromBigint(0n),

--- a/ts/shielder-sdk/package.json
+++ b/ts/shielder-sdk/package.json
@@ -23,16 +23,11 @@
     "coverage": "vitest run --coverage",
     "coverage-report": "vitest run --coverage --coverage.reporter json-summary"
   },
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
-    }
-  },
   "files": [
     "/dist"
   ],
+  "type": "module",
+  "main": "dist/index.js",
   "devDependencies": {
     "@eslint/js": "^9.14.0",
     "@types/eslint__js": "^8.42.3",

--- a/ts/shielder-sdk/src/actions/deposit.ts
+++ b/ts/shielder-sdk/src/actions/deposit.ts
@@ -16,7 +16,7 @@ import { getTokenAddress } from "@/utils";
 
 export interface DepositCalldata extends Calldata {
   calldata: {
-    pubInputs: DepositPubInputs;
+    pubInputs: DepositPubInputs<Scalar>;
     proof: Proof;
   };
   expectedContractVersion: `0x${string}`;
@@ -59,7 +59,7 @@ export class DepositAction extends NoteAction {
   async prepareAdvice(
     state: AccountState,
     amount: bigint
-  ): Promise<DepositAdvice> {
+  ): Promise<DepositAdvice<Scalar>> {
     if (state.currentNoteIndex === undefined) {
       throw new Error("currentNoteIndex must be set");
     }

--- a/ts/shielder-sdk/src/actions/withdraw.ts
+++ b/ts/shielder-sdk/src/actions/withdraw.ts
@@ -17,7 +17,7 @@ import { getTokenAddress } from "@/utils";
 export interface WithdrawCalldata {
   expectedContractVersion: `0x${string}`;
   calldata: {
-    pubInputs: WithdrawPubInputs;
+    pubInputs: WithdrawPubInputs<Scalar>;
     proof: Proof;
   };
   provingTimeMillis: number;
@@ -97,7 +97,7 @@ export class WithdrawAction extends NoteAction {
     expectedContractVersion: `0x${string}`,
     withdrawalAddress: `0x${string}`,
     totalFee: bigint
-  ): Promise<WithdrawAdvice> {
+  ): Promise<WithdrawAdvice<Scalar>> {
     if (state.currentNoteIndex === undefined) {
       throw new Error("currentNoteIndex must be set");
     }

--- a/ts/shielder-sdk/src/chain/contract.ts
+++ b/ts/shielder-sdk/src/chain/contract.ts
@@ -12,7 +12,6 @@ import { BaseError, ContractFunctionRevertedError } from "viem";
 
 import { abi } from "../_generated/abi";
 import { shieldActionGasLimit } from "@/constants";
-import { CurvePointAffine } from "@cardinal-cryptography/shielder-sdk-crypto";
 
 export class VersionRejectedByContract extends CustomError {
   public constructor() {
@@ -69,15 +68,17 @@ const getShielderContract = (
 export type IContract = {
   getAddress: () => Address;
   getMerklePath: (idx: bigint) => Promise<readonly bigint[]>;
-  anonymityRevokerPubkey: () => Promise<CurvePointAffine<bigint>>;
+  anonymityRevokerPubkey: () => Promise<readonly [bigint, bigint]>;
   newAccountNativeCalldata: (
     expectedContractVersion: `0x${string}`,
     from: Address,
     newNote: bigint,
     idHash: bigint,
     amount: bigint,
-    symKeyEncryption1: CurvePointAffine<bigint>,
-    symKeyEncryption2: CurvePointAffine<bigint>,
+    symKeyEncryption1X: bigint,
+    symKeyEncryption1Y: bigint,
+    symKeyEncryption2X: bigint,
+    symKeyEncryption2Y: bigint,
     proof: Uint8Array
   ) => Promise<`0x${string}`>;
   newAccountTokenCalldata: (
@@ -87,8 +88,10 @@ export type IContract = {
     newNote: bigint,
     idHash: bigint,
     amount: bigint,
-    symKeyEncryption1: CurvePointAffine<bigint>,
-    symKeyEncryption2: CurvePointAffine<bigint>,
+    symKeyEncryption1X: bigint,
+    symKeyEncryption1Y: bigint,
+    symKeyEncryption2X: bigint,
+    symKeyEncryption2Y: bigint,
     proof: Uint8Array
   ) => Promise<`0x${string}`>;
   depositNativeCalldata: (
@@ -139,12 +142,9 @@ export class Contract implements IContract {
     return merklePath as readonly bigint[];
   };
 
-  anonymityRevokerPubkey = async (): Promise<CurvePointAffine<bigint>> => {
+  anonymityRevokerPubkey = async (): Promise<readonly [bigint, bigint]> => {
     const key = await this.contract.read.anonymityRevokerPubkey();
-    return {
-      x: key[0],
-      y: key[1]
-    };
+    return key;
   };
 
   newAccountNativeCalldata = async (
@@ -153,8 +153,10 @@ export class Contract implements IContract {
     newNote: bigint,
     idHash: bigint,
     amount: bigint,
-    symKeyEncryption1: CurvePointAffine<bigint>,
-    symKeyEncryption2: CurvePointAffine<bigint>,
+    symKeyEncryption1X: bigint,
+    symKeyEncryption1Y: bigint,
+    symKeyEncryption2X: bigint,
+    symKeyEncryption2Y: bigint,
     proof: Uint8Array
   ) => {
     await handleWrongContractVersionError(() => {
@@ -163,10 +165,10 @@ export class Contract implements IContract {
           expectedContractVersion,
           newNote,
           idHash,
-          symKeyEncryption1.x,
-          symKeyEncryption1.y,
-          symKeyEncryption2.x,
-          symKeyEncryption2.y,
+          symKeyEncryption1X,
+          symKeyEncryption1Y,
+          symKeyEncryption2X,
+          symKeyEncryption2Y,
           bytesToHex(proof)
         ],
         { account: from, value: amount, gas: shieldActionGasLimit }
@@ -179,10 +181,10 @@ export class Contract implements IContract {
         expectedContractVersion,
         newNote,
         idHash,
-        symKeyEncryption1.x,
-        symKeyEncryption1.y,
-        symKeyEncryption2.x,
-        symKeyEncryption2.y,
+        symKeyEncryption1X,
+        symKeyEncryption1Y,
+        symKeyEncryption2X,
+        symKeyEncryption2Y,
         bytesToHex(proof)
       ]
     });
@@ -195,8 +197,10 @@ export class Contract implements IContract {
     newNote: bigint,
     idHash: bigint,
     amount: bigint,
-    symKeyEncryption1: CurvePointAffine<bigint>,
-    symKeyEncryption2: CurvePointAffine<bigint>,
+    symKeyEncryption1X: bigint,
+    symKeyEncryption1Y: bigint,
+    symKeyEncryption2X: bigint,
+    symKeyEncryption2Y: bigint,
     proof: Uint8Array
   ) => {
     await handleWrongContractVersionError(() => {
@@ -207,10 +211,10 @@ export class Contract implements IContract {
           amount,
           newNote,
           idHash,
-          symKeyEncryption1.x,
-          symKeyEncryption1.y,
-          symKeyEncryption2.x,
-          symKeyEncryption2.y,
+          symKeyEncryption1X,
+          symKeyEncryption1Y,
+          symKeyEncryption2X,
+          symKeyEncryption2Y,
           bytesToHex(proof)
         ],
         { account: from, gas: shieldActionGasLimit }
@@ -225,10 +229,10 @@ export class Contract implements IContract {
         amount,
         newNote,
         idHash,
-        symKeyEncryption1.x,
-        symKeyEncryption1.y,
-        symKeyEncryption2.x,
-        symKeyEncryption2.y,
+        symKeyEncryption1X,
+        symKeyEncryption1Y,
+        symKeyEncryption2X,
+        symKeyEncryption2Y,
         bytesToHex(proof)
       ]
     });

--- a/ts/shielder-sdk/src/index.ts
+++ b/ts/shielder-sdk/src/index.ts
@@ -7,8 +7,12 @@ export {
   QuotedFees,
   ShielderOperation
 } from "@/client";
-export { type AccountState, type ShielderTransaction } from "@/state";
-export { accountObjectSchema, InjectedStorageInterface } from "@/state";
+export {
+  type AccountState,
+  type ShielderTransaction,
+  accountObjectSchema,
+  InjectedStorageInterface
+} from "@/state";
 export {
   type ERC20Token,
   type NativeToken,


### PR DESCRIPTION
In this PR we:
- make types (such as `DepositAdvice`, `DepositPubInto`) in shielder-sdk-crypto generic, allowing them to be independent of `Scalar` object. This will be useful in mobile bindings.
- remove `CurvePointAffine`, as this wrapper doesn't bring much value. All integrated interfaces: wasm bindings, smart contracts and mobile bindings in future will have flat inputs, so structuring curve point just adds more wrapping/unwrapping logic.