### PR TITLE
Extract proving keys&params from bindings

### DIFF
--- a/.github/actions/prepare-rust-env/action.yml
+++ b/.github/actions/prepare-rust-env/action.yml
@@ -1,13 +1,13 @@
 ---
-name: 'Prepare Rust environment'
+name: "Prepare Rust environment"
 description: >
   Installs Rust toolchain, authenticates with SSH (in order to access Github private repos)
 inputs:
   poseidon-gadget-private-key:
-    description: 'SSH private key that corresponds to the deploy key in poseidon2-gadget repository'
+    description: "SSH private key that corresponds to the deploy key in poseidon2-gadget repository"
     required: true
   zkos-circuits-private-key:
-    description: 'SSH private key that corresponds to the deploy key in zkos-circuits repository'
+    description: "SSH private key that corresponds to the deploy key in zkos-circuits repository"
     required: true
 
 runs:
@@ -23,6 +23,10 @@ runs:
       uses: Cardinal-Cryptography/github-actions/install-rust-toolchain@v7
       with:
         channel: nightly
+
+    - name: Install active toolchain
+      shell: bash
+      run: rustup toolchain install
 
     - name: Install sccache
       shell: bash

--- a/.github/workflows/_build-wasm-packages.yml
+++ b/.github/workflows/_build-wasm-packages.yml
@@ -33,3 +33,10 @@ jobs:
           name: wasm-pkg
           path: crates/shielder_bindings/pkg
           retention-days: 1
+
+      - name: Upload generated proving keys to artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: proving-keys-pkg
+          path: crates/shielder_bindings/artifacts
+          retention-days: 1

--- a/.github/workflows/_ts-checks.yml
+++ b/.github/workflows/_ts-checks.yml
@@ -35,6 +35,12 @@ jobs:
           name: wasm-pkg
           path: crates/shielder_bindings/pkg
 
+      - name: Download generated proving keys from artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: proving-keys-pkg
+          path: crates/shielder_bindings/artifacts
+
       - name: Download generated build cache
         uses: actions/download-artifact@v4
         with:
@@ -114,6 +120,12 @@ jobs:
         with:
           name: wasm-pkg
           path: crates/shielder_bindings/pkg
+
+      - name: Download generated proving keys from artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: proving-keys-pkg
+          path: crates/shielder_bindings/artifacts
 
       - name: Download generated build cache
         uses: actions/download-artifact@v4

--- a/.github/workflows/on-pull-request-commit.yml
+++ b/.github/workflows/on-pull-request-commit.yml
@@ -54,7 +54,9 @@ jobs:
     steps:
       - uses: geekyeggo/delete-artifact@v5
         with:
-          name: wasm-pkg
+          name: |
+            wasm-pkg
+            proving-keys-pkg
 
   measure-gas-usage-and-verifier-code-size:
     name: Measure gas usage

--- a/crates/shielder_bindings/src/circuits/deposit.rs
+++ b/crates/shielder_bindings/src/circuits/deposit.rs
@@ -61,8 +61,8 @@ pub struct DepositCircuit(super::DepositCircuit);
 impl DepositCircuit {
     #[cfg_attr(feature = "build-uniffi", uniffi::constructor)]
     #[cfg_attr(feature = "build-wasm", wasm_bindgen(constructor))]
-    pub fn new_pronto() -> Self {
-        DepositCircuit(super::DepositCircuit::new_pronto())
+    pub fn new_pronto(params_buf: &[u8], pk_buf: &[u8]) -> Self {
+        DepositCircuit(super::DepositCircuit::new_pronto(params_buf, pk_buf))
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/shielder_bindings/src/circuits/new_account.rs
+++ b/crates/shielder_bindings/src/circuits/new_account.rs
@@ -74,8 +74,8 @@ pub struct NewAccountCircuit(super::NewAccountCircuit);
 impl NewAccountCircuit {
     #[cfg_attr(feature = "build-uniffi", uniffi::constructor)]
     #[cfg_attr(feature = "build-wasm", wasm_bindgen(constructor))]
-    pub fn new_pronto() -> Self {
-        NewAccountCircuit(super::NewAccountCircuit::new_pronto())
+    pub fn new_pronto(params_buf: &[u8], pk_buf: &[u8]) -> Self {
+        NewAccountCircuit(super::NewAccountCircuit::new_pronto(params_buf, pk_buf))
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/shielder_bindings/src/circuits/withdraw.rs
+++ b/crates/shielder_bindings/src/circuits/withdraw.rs
@@ -67,8 +67,8 @@ pub struct WithdrawCircuit(super::WithdrawCircuit);
 impl WithdrawCircuit {
     #[cfg_attr(feature = "build-uniffi", uniffi::constructor)]
     #[cfg_attr(feature = "build-wasm", wasm_bindgen(constructor))]
-    pub fn new_pronto() -> Self {
-        WithdrawCircuit(super::WithdrawCircuit::new_pronto())
+    pub fn new_pronto(params_buf: &[u8], pk_buf: &[u8]) -> Self {
+        WithdrawCircuit(super::WithdrawCircuit::new_pronto(params_buf, pk_buf))
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/ts/.gitignore
+++ b/ts/.gitignore
@@ -1,2 +1,3 @@
 dist/
 dist-vite/
+dist-keys/

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -199,7 +199,7 @@ importers:
         specifier: ^1.45.0
         version: 1.50.1
       '@types/node':
-        specifier: ^20.14.14
+        specifier: ^20.17.19
         version: 20.17.19
       '@types/react':
         specifier: ^18.3.3

--- a/ts/shielder-sdk-crypto-wasm/build.sh
+++ b/ts/shielder-sdk-crypto-wasm/build.sh
@@ -14,3 +14,5 @@ node update-imports.mjs
 # Create Vite-specific build
 ./patches/vite-patch.sh
 
+# Copy Proving keys
+./copy-keys.sh

--- a/ts/shielder-sdk-crypto-wasm/copy-keys.sh
+++ b/ts/shielder-sdk-crypto-wasm/copy-keys.sh
@@ -8,11 +8,14 @@ mkdir -p dist-keys/deposit
 mkdir -p dist-keys/withdraw
 
 # Copy binary files from artifacts to dist-keys
-cp ../../crates/shielder_bindings/artifacts/new_account/params.bin dist-keys/new_account/
-cp ../../crates/shielder_bindings/artifacts/new_account/pk.bin dist-keys/new_account/
-cp ../../crates/shielder_bindings/artifacts/deposit/params.bin dist-keys/deposit/
-cp ../../crates/shielder_bindings/artifacts/deposit/pk.bin dist-keys/deposit/
-cp ../../crates/shielder_bindings/artifacts/withdraw/params.bin dist-keys/withdraw/
-cp ../../crates/shielder_bindings/artifacts/withdraw/pk.bin dist-keys/withdraw/
+cp ../../crates/shielder_bindings/artifacts/new_account/params.bin \
+    ../../crates/shielder_bindings/artifacts/new_account/pk.bin \
+    dist-keys/new_account/
+cp ../../crates/shielder_bindings/artifacts/deposit/params.bin \
+    ../../crates/shielder_bindings/artifacts/deposit/pk.bin \
+    dist-keys/deposit/
+cp ../../crates/shielder_bindings/artifacts/withdraw/params.bin \
+    ../../crates/shielder_bindings/artifacts/withdraw/pk.bin \
+    dist-keys/withdraw/
 
 echo "Circuit key files copied to dist-keys directory"

--- a/ts/shielder-sdk-crypto-wasm/copy-keys.sh
+++ b/ts/shielder-sdk-crypto-wasm/copy-keys.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Create dist-keys directory and subdirectories
+mkdir -p dist-keys/new_account
+mkdir -p dist-keys/deposit
+mkdir -p dist-keys/withdraw
+
+# Copy binary files from artifacts to dist-keys
+cp ../../crates/shielder_bindings/artifacts/new_account/params.bin dist-keys/new_account/
+cp ../../crates/shielder_bindings/artifacts/new_account/pk.bin dist-keys/new_account/
+cp ../../crates/shielder_bindings/artifacts/deposit/params.bin dist-keys/deposit/
+cp ../../crates/shielder_bindings/artifacts/deposit/pk.bin dist-keys/deposit/
+cp ../../crates/shielder_bindings/artifacts/withdraw/params.bin dist-keys/withdraw/
+cp ../../crates/shielder_bindings/artifacts/withdraw/pk.bin dist-keys/withdraw/
+
+echo "Circuit key files copied to dist-keys directory"

--- a/ts/shielder-sdk-crypto-wasm/package.json
+++ b/ts/shielder-sdk-crypto-wasm/package.json
@@ -18,7 +18,8 @@
   "license": "Apache-2.0",
   "files": [
     "/dist",
-    "/dist-vite"
+    "/dist-vite",
+    "/dist-keys"
   ],
   "exports": {
     ".": {
@@ -40,7 +41,8 @@
       "import": "./dist/crates/shielder_bindings/pkg/pkg-web-multithreaded/shielder_bindings_bg.wasm",
       "require": "./dist/crates/shielder_bindings/pkg/pkg-web-multithreaded/shielder_bindings_bg.wasm",
       "types": "./dist/crates/shielder_bindings/pkg/pkg-web-multithreaded/shielder_bindings_bg.wasm.d.ts"
-    }
+    },
+    "./keys/*": "./dist-keys/*"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/ts/shielder-sdk-crypto-wasm/src/circuits/deposit.ts
+++ b/ts/shielder-sdk-crypto-wasm/src/circuits/deposit.ts
@@ -17,12 +17,12 @@ export class DepositCircuit
   implements IDepositCircuit
 {
   private wasmCircuit: InstanceType<WasmDepositCircuit> | undefined;
-  init(caller: Caller) {
+  init(caller: Caller, params_buf: Uint8Array, pk_buf: Uint8Array) {
     super.init(caller);
     if (!this.wasmModule) {
       throw new Error("Wasm module not loaded");
     }
-    this.wasmCircuit = new this.wasmModule.DepositCircuit();
+    this.wasmCircuit = new this.wasmModule.DepositCircuit(params_buf, pk_buf);
   }
 
   prove(values: DepositAdvice<Scalar>): Promise<Proof> {

--- a/ts/shielder-sdk-crypto-wasm/src/circuits/deposit.ts
+++ b/ts/shielder-sdk-crypto-wasm/src/circuits/deposit.ts
@@ -7,6 +7,7 @@ import {
 } from "@cardinal-cryptography/shielder-sdk-crypto";
 import { Caller } from "../wasmClient";
 import { WasmClientModuleBase } from "../utils/wasmModuleLoader";
+import { CircuitParamsPkBuffer } from "@/types";
 
 type WasmDepositCircuit =
   | typeof import("shielder_bindings/web-singlethreaded").DepositCircuit
@@ -17,12 +18,15 @@ export class DepositCircuit
   implements IDepositCircuit
 {
   private wasmCircuit: InstanceType<WasmDepositCircuit> | undefined;
-  init(caller: Caller, params_buf: Uint8Array, pk_buf: Uint8Array) {
+  init(caller: Caller, buf: CircuitParamsPkBuffer) {
     super.init(caller);
     if (!this.wasmModule) {
       throw new Error("Wasm module not loaded");
     }
-    this.wasmCircuit = new this.wasmModule.DepositCircuit(params_buf, pk_buf);
+    this.wasmCircuit = new this.wasmModule.DepositCircuit(
+      buf.paramsBuf,
+      buf.pkBuf
+    );
   }
 
   prove(values: DepositAdvice<Scalar>): Promise<Proof> {

--- a/ts/shielder-sdk-crypto-wasm/src/circuits/newAccount.ts
+++ b/ts/shielder-sdk-crypto-wasm/src/circuits/newAccount.ts
@@ -7,6 +7,7 @@ import {
 } from "@cardinal-cryptography/shielder-sdk-crypto";
 import { Caller } from "../wasmClient";
 import { WasmClientModuleBase } from "../utils/wasmModuleLoader";
+import { CircuitParamsPkBuffer } from "@/types";
 
 type WasmNewAccountCircuit =
   | typeof import("shielder_bindings/web-singlethreaded").NewAccountCircuit
@@ -18,14 +19,14 @@ export class NewAccountCircuit
 {
   private wasmCircuit: InstanceType<WasmNewAccountCircuit> | undefined;
 
-  init(caller: Caller, params_buf: Uint8Array, pk_buf: Uint8Array) {
+  init(caller: Caller, buf: CircuitParamsPkBuffer) {
     super.init(caller);
     if (!this.wasmModule) {
       throw new Error("Wasm module not loaded");
     }
     this.wasmCircuit = new this.wasmModule.NewAccountCircuit(
-      params_buf,
-      pk_buf
+      buf.paramsBuf,
+      buf.pkBuf
     );
   }
 

--- a/ts/shielder-sdk-crypto-wasm/src/circuits/newAccount.ts
+++ b/ts/shielder-sdk-crypto-wasm/src/circuits/newAccount.ts
@@ -18,12 +18,15 @@ export class NewAccountCircuit
 {
   private wasmCircuit: InstanceType<WasmNewAccountCircuit> | undefined;
 
-  init(caller: Caller) {
+  init(caller: Caller, params_buf: Uint8Array, pk_buf: Uint8Array) {
     super.init(caller);
     if (!this.wasmModule) {
       throw new Error("Wasm module not loaded");
     }
-    this.wasmCircuit = new this.wasmModule.NewAccountCircuit();
+    this.wasmCircuit = new this.wasmModule.NewAccountCircuit(
+      params_buf,
+      pk_buf
+    );
   }
 
   prove(values: NewAccountAdvice<Scalar>): Promise<Proof> {

--- a/ts/shielder-sdk-crypto-wasm/src/circuits/withdraw.ts
+++ b/ts/shielder-sdk-crypto-wasm/src/circuits/withdraw.ts
@@ -17,12 +17,12 @@ export class WithdrawCircuit
   implements IWithdrawCircuit
 {
   private wasmCircuit: InstanceType<WasmWithdrawCircuit> | undefined;
-  init(caller: Caller) {
+  init(caller: Caller, params_buf: Uint8Array, pk_buf: Uint8Array) {
     super.init(caller);
     if (!this.wasmModule) {
       throw new Error("Wasm module not loaded");
     }
-    this.wasmCircuit = new this.wasmModule.WithdrawCircuit();
+    this.wasmCircuit = new this.wasmModule.WithdrawCircuit(params_buf, pk_buf);
   }
 
   prove(values: WithdrawAdvice<Scalar>): Promise<Proof> {

--- a/ts/shielder-sdk-crypto-wasm/src/circuits/withdraw.ts
+++ b/ts/shielder-sdk-crypto-wasm/src/circuits/withdraw.ts
@@ -7,6 +7,7 @@ import {
 } from "@cardinal-cryptography/shielder-sdk-crypto";
 import { Caller } from "../wasmClient";
 import { WasmClientModuleBase } from "../utils/wasmModuleLoader";
+import { CircuitParamsPkBuffer } from "@/types";
 
 type WasmWithdrawCircuit =
   | typeof import("shielder_bindings/web-singlethreaded").WithdrawCircuit
@@ -17,12 +18,15 @@ export class WithdrawCircuit
   implements IWithdrawCircuit
 {
   private wasmCircuit: InstanceType<WasmWithdrawCircuit> | undefined;
-  init(caller: Caller, params_buf: Uint8Array, pk_buf: Uint8Array) {
+  init(caller: Caller, buf: CircuitParamsPkBuffer) {
     super.init(caller);
     if (!this.wasmModule) {
       throw new Error("Wasm module not loaded");
     }
-    this.wasmCircuit = new this.wasmModule.WithdrawCircuit(params_buf, pk_buf);
+    this.wasmCircuit = new this.wasmModule.WithdrawCircuit(
+      buf.paramsBuf,
+      buf.pkBuf
+    );
   }
 
   prove(values: WithdrawAdvice<Scalar>): Promise<Proof> {

--- a/ts/shielder-sdk-crypto-wasm/src/types.ts
+++ b/ts/shielder-sdk-crypto-wasm/src/types.ts
@@ -1,0 +1,4 @@
+export type CircuitParamsPkBuffer = {
+  paramsBuf: Uint8Array;
+  pkBuf: Uint8Array;
+};

--- a/ts/shielder-sdk-crypto-wasm/src/wasmClient.ts
+++ b/ts/shielder-sdk-crypto-wasm/src/wasmClient.ts
@@ -35,6 +35,12 @@ export class WasmClient implements CryptoClient {
   async init(
     caller: Caller,
     threads: number,
+    new_account_params_buf: Uint8Array,
+    new_account_pk_buf: Uint8Array,
+    deposit_params_buf: Uint8Array,
+    deposit_pk_buf: Uint8Array,
+    withdraw_params_buf: Uint8Array,
+    withdraw_pk_buf: Uint8Array,
     wasm_url?: string
   ): Promise<void> {
     const time = Date.now();
@@ -47,9 +53,13 @@ export class WasmClient implements CryptoClient {
     } else {
       throw new Error("Invalid caller");
     }
-    this.newAccountCircuit.init(caller);
-    this.depositCircuit.init(caller);
-    this.withdrawCircuit.init(caller);
+    this.newAccountCircuit.init(
+      caller,
+      new_account_params_buf,
+      new_account_pk_buf
+    );
+    this.depositCircuit.init(caller, deposit_params_buf, deposit_pk_buf);
+    this.withdrawCircuit.init(caller, withdraw_params_buf, withdraw_pk_buf);
     this.hasher.init(caller);
     this.secretManager.init(caller);
     this.noteTreeConfig.init(caller);

--- a/ts/shielder-sdk-crypto-wasm/src/wasmClient.ts
+++ b/ts/shielder-sdk-crypto-wasm/src/wasmClient.ts
@@ -8,6 +8,7 @@ import { SecretGenerator } from "@/secretGenerator";
 import { NoteTreeConfig } from "@/noteTreeConfig";
 import { CryptoClient } from "@cardinal-cryptography/shielder-sdk-crypto";
 import { Converter } from "@/conversion";
+import { CircuitParamsPkBuffer } from "./types";
 
 export type Caller = "web_singlethreaded" | "web_multithreaded";
 
@@ -35,12 +36,9 @@ export class WasmClient implements CryptoClient {
   async init(
     caller: Caller,
     threads: number,
-    new_account_params_buf: Uint8Array,
-    new_account_pk_buf: Uint8Array,
-    deposit_params_buf: Uint8Array,
-    deposit_pk_buf: Uint8Array,
-    withdraw_params_buf: Uint8Array,
-    withdraw_pk_buf: Uint8Array,
+    newAccountBuf: CircuitParamsPkBuffer,
+    depositBuf: CircuitParamsPkBuffer,
+    withdrawBuf: CircuitParamsPkBuffer,
     wasm_url?: string
   ): Promise<void> {
     const time = Date.now();
@@ -53,13 +51,9 @@ export class WasmClient implements CryptoClient {
     } else {
       throw new Error("Invalid caller");
     }
-    this.newAccountCircuit.init(
-      caller,
-      new_account_params_buf,
-      new_account_pk_buf
-    );
-    this.depositCircuit.init(caller, deposit_params_buf, deposit_pk_buf);
-    this.withdrawCircuit.init(caller, withdraw_params_buf, withdraw_pk_buf);
+    this.newAccountCircuit.init(caller, newAccountBuf);
+    this.depositCircuit.init(caller, depositBuf);
+    this.withdrawCircuit.init(caller, withdrawBuf);
     this.hasher.init(caller);
     this.secretManager.init(caller);
     this.noteTreeConfig.init(caller);

--- a/ts/shielder-sdk-crypto-wasm/src/wasmClientWorker.ts
+++ b/ts/shielder-sdk-crypto-wasm/src/wasmClientWorker.ts
@@ -38,12 +38,24 @@ expose(exposed);
  * Pass `wasm_url` only if you need the special setup (such as vite-patched distribution).
  *
  * @param threads - The number of threads to use (1 for single-threaded, >1 for multi-threaded).
+ * @param new_account_params_buf - Uint8Array containing the new account params binary data
+ * @param new_account_pk_buf - Uint8Array containing the new account pk binary data
+ * @param deposit_params_buf - Uint8Array containing the deposit params binary data
+ * @param deposit_pk_buf - Uint8Array containing the deposit pk binary data
+ * @param withdraw_params_buf - Uint8Array containing the withdraw params binary data
+ * @param withdraw_pk_buf - Uint8Array containing the withdraw pk binary data
  * @param wasm_url - Optional URL to the WASM binary.
  * @returns A promise that resolves to a Comlink-wrapped worker implementing CryptoClient.
  * @throws Will throw an error if the worker initialization fails.
  */
 export const initWasmWorker = async (
   threads: number,
+  new_account_params_buf: Uint8Array,
+  new_account_pk_buf: Uint8Array,
+  deposit_params_buf: Uint8Array,
+  deposit_pk_buf: Uint8Array,
+  withdraw_params_buf: Uint8Array,
+  withdraw_pk_buf: Uint8Array,
   wasm_url?: string
 ): Promise<CryptoClient> => {
   // Create a new worker instance
@@ -60,7 +72,17 @@ export const initWasmWorker = async (
   try {
     // Initialize with single or multi-threaded mode
     const caller = threads === 1 ? "web_singlethreaded" : "web_multithreaded";
-    await wrappedWorker.init(caller, threads, wasm_url);
+    await wrappedWorker.init(
+      caller,
+      threads,
+      new_account_params_buf,
+      new_account_pk_buf,
+      deposit_params_buf,
+      deposit_pk_buf,
+      withdraw_params_buf,
+      withdraw_pk_buf,
+      wasm_url
+    );
     return wrappedWorker;
   } catch (error) {
     console.error("Failed to initialize WASM worker:", error);

--- a/ts/shielder-sdk-crypto-wasm/src/wasmClientWorker.ts
+++ b/ts/shielder-sdk-crypto-wasm/src/wasmClientWorker.ts
@@ -1,6 +1,7 @@
 import { expose, wrap } from "comlink";
 import { WasmClient } from "./wasmClient";
 import { CryptoClient } from "@cardinal-cryptography/shielder-sdk-crypto";
+import { CircuitParamsPkBuffer } from "./types";
 
 // Create worker instance
 const wasmClientWorker = new WasmClient();
@@ -50,12 +51,9 @@ expose(exposed);
  */
 export const initWasmWorker = async (
   threads: number,
-  new_account_params_buf: Uint8Array,
-  new_account_pk_buf: Uint8Array,
-  deposit_params_buf: Uint8Array,
-  deposit_pk_buf: Uint8Array,
-  withdraw_params_buf: Uint8Array,
-  withdraw_pk_buf: Uint8Array,
+  newAccountBuf: CircuitParamsPkBuffer,
+  depositBuf: CircuitParamsPkBuffer,
+  withdrawBuf: CircuitParamsPkBuffer,
   wasm_url?: string
 ): Promise<CryptoClient> => {
   // Create a new worker instance
@@ -75,12 +73,9 @@ export const initWasmWorker = async (
     await wrappedWorker.init(
       caller,
       threads,
-      new_account_params_buf,
-      new_account_pk_buf,
-      deposit_params_buf,
-      deposit_pk_buf,
-      withdraw_params_buf,
-      withdraw_pk_buf,
+      newAccountBuf,
+      depositBuf,
+      withdrawBuf,
       wasm_url
     );
     return wrappedWorker;

--- a/ts/shielder-sdk-tests/package.json
+++ b/ts/shielder-sdk-tests/package.json
@@ -18,7 +18,7 @@
     "@cardinal-cryptography/shielder-sdk-crypto": "workspace:*",
     "@cardinal-cryptography/shielder-sdk-crypto-wasm": "workspace:*",
     "@playwright/test": "^1.45.0",
-    "@types/node": "^20.14.14",
+    "@types/node": "^20.17.19",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",

--- a/ts/shielder-sdk-tests/tsconfig.json
+++ b/ts/shielder-sdk-tests/tsconfig.json
@@ -24,7 +24,8 @@
       "@/*": ["./web/*"],
       "@tests/*": ["./tests/*"],
       "~*": ["./web/*"]
-    }
+    },
+    "types": ["vite/client", "node"]
   },
   "include": [".plasmo/index.d.ts", "web/**/*", "tests/**/*"]
 }

--- a/ts/shielder-sdk-tests/web/EntryPoint.tsx
+++ b/ts/shielder-sdk-tests/web/EntryPoint.tsx
@@ -18,6 +18,13 @@ import {
   setupShielderTest
 } from "./fixtures/shielderTest/setup";
 
+import newAccountParamsUrl from "@cardinal-cryptography/shielder-sdk-crypto-wasm/keys/new_account/params.bin?url";
+import newAccountPkUrl from "@cardinal-cryptography/shielder-sdk-crypto-wasm/keys/new_account/pk.bin?url";
+import depositParamsUrl from "@cardinal-cryptography/shielder-sdk-crypto-wasm/keys/deposit/params.bin?url";
+import depositPkUrl from "@cardinal-cryptography/shielder-sdk-crypto-wasm/keys/deposit/pk.bin?url";
+import withdrawParamsUrl from "@cardinal-cryptography/shielder-sdk-crypto-wasm/keys/withdraw/params.bin?url";
+import withdrawPkUrl from "@cardinal-cryptography/shielder-sdk-crypto-wasm/keys/withdraw/pk.bin?url";
+
 declare global {
   interface Window {
     wasmCryptoClient: {
@@ -49,20 +56,41 @@ declare global {
   }
 }
 
+async function fetchArrayBuffer(url: string | URL): Promise<Uint8Array> {
+  return await fetch(url as string | URL).then((r) => r.bytes());
+}
+
 function EntryPoint() {
   useEffect(() => {
-    // test fixtures initialization
-    window.testFixtures = window.testFixtures || {};
-    window.testFixtures.setupHappyTest = setupShielderTest;
-    // Wasm crypto client initialization
-    window.wasmCryptoClient = window.wasmCryptoClient || {};
-    window.wasmCryptoClient.cryptoClient = initWasmWorker(envThreadsNumber());
-    // Expose shielder utilities
-    window.shielder = window.shielder || {};
-    window.shielder.createShielderClient = createShielderClient;
-    window.shielder.nativeToken = nativeToken;
-    window.shielder.erc20Token = erc20Token;
-    window.initialized = true;
+    const initialize = async () => {
+      const newAccountParams = await fetchArrayBuffer(newAccountParamsUrl);
+      const newAccountPk = await fetchArrayBuffer(newAccountPkUrl);
+      const depositParams = await fetchArrayBuffer(depositParamsUrl);
+      const depositPk = await fetchArrayBuffer(depositPkUrl);
+      const withdrawParams = await fetchArrayBuffer(withdrawParamsUrl);
+      const withdrawPk = await fetchArrayBuffer(withdrawPkUrl);
+      // test fixtures initialization
+      window.testFixtures = window.testFixtures || {};
+      window.testFixtures.setupHappyTest = setupShielderTest;
+      // Wasm crypto client initialization
+      window.wasmCryptoClient = window.wasmCryptoClient || {};
+      window.wasmCryptoClient.cryptoClient = initWasmWorker(
+        envThreadsNumber(),
+        newAccountParams,
+        newAccountPk,
+        depositParams,
+        depositPk,
+        withdrawParams,
+        withdrawPk
+      );
+      // Expose shielder utilities
+      window.shielder = window.shielder || {};
+      window.shielder.createShielderClient = createShielderClient;
+      window.shielder.nativeToken = nativeToken;
+      window.shielder.erc20Token = erc20Token;
+      window.initialized = true;
+    };
+    void initialize();
   }, []);
 
   return null;

--- a/ts/shielder-sdk-tests/web/EntryPoint.tsx
+++ b/ts/shielder-sdk-tests/web/EntryPoint.tsx
@@ -56,8 +56,8 @@ declare global {
   }
 }
 
-async function fetchArrayBuffer(url: string | URL): Promise<Uint8Array> {
-  return await fetch(url as string | URL).then((r) => r.bytes());
+async function fetchArrayBuffer(url: string): Promise<Uint8Array> {
+  return await fetch(url).then((r) => r.bytes());
 }
 
 function EntryPoint() {
@@ -76,12 +76,18 @@ function EntryPoint() {
       window.wasmCryptoClient = window.wasmCryptoClient || {};
       window.wasmCryptoClient.cryptoClient = initWasmWorker(
         envThreadsNumber(),
-        newAccountParams,
-        newAccountPk,
-        depositParams,
-        depositPk,
-        withdrawParams,
-        withdrawPk
+        {
+          paramsBuf: newAccountParams,
+          pkBuf: newAccountPk
+        },
+        {
+          paramsBuf: depositParams,
+          pkBuf: depositPk
+        },
+        {
+          paramsBuf: withdrawParams,
+          pkBuf: withdrawPk
+        }
       );
       // Expose shielder utilities
       window.shielder = window.shielder || {};


### PR DESCRIPTION
- extracting halo2 proving key and params from bindings
- circuits now are initialized with `&[u8]` buffer, which translates to `Uint8Array` buffer in js env
- packing pk and params in separate entrypoint of `shielder-sdk-crypto-wasm`, example usage can be seen in e2e playwright tests:

https://github.com/Cardinal-Cryptography/zkOS-monorepo/blob/32da2b745782091025b6254f3b4fca0550f45955/ts/shielder-sdk-tests/web/EntryPoint.tsx#L21-L26

https://github.com/Cardinal-Cryptography/zkOS-monorepo/blob/32da2b745782091025b6254f3b4fca0550f45955/ts/shielder-sdk-tests/web/EntryPoint.tsx#L59-L85