### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/_check-vars-and-secrets.yml
+++ b/.github/workflows/_check-vars-and-secrets.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   main:
     name: Check available vars and secrets
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check vars
         run: |


### PR DESCRIPTION
ubuntu-20.04 has just stopped being supported, which causes our workflow to fail. See https://github.com/actions/runner-images/issues/11101