### PR TITLE
Sdk refactor #1

### DIFF
--- a/ts/shielder-sdk/__tests/actions/newAccount.test.ts
+++ b/ts/shielder-sdk/__tests/actions/newAccount.test.ts
@@ -11,9 +11,10 @@ import { MockedCryptoClient, hashedNote } from "../helpers";
 
 import { NewAccountAction } from "../../src/actions/newAccount";
 import { AccountState } from "../../src/state";
-import { IContract, VersionRejectedByContract } from "../../src/chain/contract";
+import { IContract } from "../../src/chain/contract";
 import { SendShielderTransaction } from "../../src/client";
 import { nativeToken } from "../../src/types";
+import { OutdatedSdkError } from "../../src/errors";
 
 const ANONYMITY_REVOKER_PUBKEY = [123n, 456n];
 
@@ -58,7 +59,6 @@ describe("NewAccountAction", () => {
       nonce: mockedStateNonce,
       balance: 0n,
       currentNote: Scalar.fromBigint(0n),
-      storageSchemaVersion: 0,
       token: nativeToken()
     };
   });
@@ -197,7 +197,7 @@ describe("NewAccountAction", () => {
         expectedVersion
       );
 
-      const mockedErr = new VersionRejectedByContract();
+      const mockedErr = new OutdatedSdkError("123");
 
       contract.newAccountNativeCalldata = vitest
         .fn<

--- a/ts/shielder-sdk/__tests/actions/withdraw.test.ts
+++ b/ts/shielder-sdk/__tests/actions/withdraw.test.ts
@@ -10,21 +10,18 @@ import {
 import { MockedCryptoClient, hashedNote } from "../helpers";
 
 import { WithdrawAction } from "../../src/actions/withdraw";
-import { AccountState } from "../../src/state";
 import { IContract } from "../../src/chain/contract";
-import {
-  IRelayer,
-  VersionRejectedByRelayer,
-  WithdrawResponse
-} from "../../src/chain/relayer";
+import { IRelayer, WithdrawResponse } from "../../src/chain/relayer";
 import { nativeToken, Token } from "../../src/types";
+import { OutdatedSdkError } from "../../src/errors";
+import { AccountStateMerkleIndexed } from "../../src/state/types";
 
 describe("WithdrawAction", () => {
   let cryptoClient: MockedCryptoClient;
   let contract: IContract;
   let relayer: IRelayer;
   let action: WithdrawAction;
-  let state: AccountState;
+  let state: AccountStateMerkleIndexed;
   const stateNonce = 1n;
   const prevNullifier = Scalar.fromBigint(2n);
   const prevTrapdoor = Scalar.fromBigint(3n);
@@ -107,7 +104,6 @@ describe("WithdrawAction", () => {
         Scalar.fromBigint(5n)
       ),
       currentNoteIndex: 100n,
-      storageSchemaVersion: 0,
       token: nativeToken()
     };
   });
@@ -169,25 +165,6 @@ describe("WithdrawAction", () => {
 
       // Expected contract version should be equal to input expected version
       expect(calldata.expectedContractVersion).toBe(expectedVersion);
-    });
-
-    it("should throw on undefined currentNoteIndex", async () => {
-      const amount = 2n;
-      const expectedVersion = "0xversio" as `0x${string}`;
-      const totalFee = 1n;
-      await expect(
-        action.generateCalldata(
-          {
-            ...state,
-            currentNoteIndex: undefined
-          },
-          amount,
-          mockRelayerAddress,
-          totalFee,
-          mockAddress,
-          expectedVersion
-        )
-      ).rejects.toThrow("currentNoteIndex must be set");
     });
 
     it("should throw on balance less than amount", async () => {
@@ -316,7 +293,7 @@ describe("WithdrawAction", () => {
         expectedVersion
       );
 
-      const mockedErr = new VersionRejectedByRelayer("rejected version");
+      const mockedErr = new OutdatedSdkError("123");
 
       relayer.withdraw = vitest
         .fn<

--- a/ts/shielder-sdk/__tests/state/events.test.ts
+++ b/ts/shielder-sdk/__tests/state/events.test.ts
@@ -1,6 +1,6 @@
 import { it, expect, describe, beforeEach } from "vitest";
 import { MockedCryptoClient } from "../helpers";
-import { AccountState, StateEventsFilter } from "../../src/state";
+import { StateEventsFilter } from "../../src/state";
 import {
   NewAccountAction,
   DepositAction,
@@ -15,13 +15,16 @@ import {
   scalarToBigint
 } from "@cardinal-cryptography/shielder-sdk-crypto";
 import { nativeToken } from "../../src/types";
+import { AccountStateMerkleIndexed } from "../../src/state/types";
 
-const expectStatesEqual = (state1: AccountState, state2: AccountState) => {
+const expectStatesEqual = (
+  state1: AccountStateMerkleIndexed,
+  state2: AccountStateMerkleIndexed
+) => {
   expect(scalarsEqual(state1.id, state2.id)).toBe(true);
   expect(state1.nonce).toBe(state2.nonce);
   expect(state1.balance).toBe(state2.balance);
   expect(scalarsEqual(state1.currentNote, state2.currentNote)).toBe(true);
-  expect(state1.storageSchemaVersion).toBe(state2.storageSchemaVersion);
 };
 
 describe("StateEventsFilter", () => {
@@ -34,7 +37,7 @@ describe("StateEventsFilter", () => {
   let withdrawAction: WithdrawAction;
   let nonceGenerator: INonceGenerator;
 
-  let initialState: AccountState;
+  let initialState: AccountStateMerkleIndexed;
 
   beforeEach(() => {
     cryptoClient = new MockedCryptoClient();
@@ -64,7 +67,6 @@ describe("StateEventsFilter", () => {
       currentNoteIndex: 1n,
       nonce: 0n,
       balance: 100n,
-      storageSchemaVersion: 1,
       token: nativeToken()
     };
   });
@@ -168,7 +170,7 @@ describe("StateEventsFilter", () => {
       if (!expectedNewState) {
         throw new Error("expectedNewState is null");
       }
-      expect(newState?.currentNoteIndex).toBe(4n);
+      expect(newState.currentNoteIndex).toBe(4n);
       expectStatesEqual(newState, expectedNewState);
     });
 

--- a/ts/shielder-sdk/__tests/state/storageSchema.test.ts
+++ b/ts/shielder-sdk/__tests/state/storageSchema.test.ts
@@ -46,25 +46,6 @@ describe("storageSchema", () => {
     });
   });
 
-  it("should validate state without optional currentNoteIndex", () => {
-    const validState = {
-      nonce: "1",
-      balance: "1000",
-      idHash: "12345",
-      currentNote: "67890",
-      storageSchemaVersion: 2
-    };
-
-    const result = accountObjectSchema.parse(validState);
-    expect(result).toEqual({
-      nonce: 1n,
-      balance: 1000n,
-      idHash: 12345n,
-      currentNote: 67890n,
-      storageSchemaVersion: 2
-    });
-  });
-
   it.each([
     {
       invalidState: {
@@ -130,6 +111,7 @@ describe("createStorage", () => {
       balance: "1000",
       idHash: "12345",
       currentNote: "67890",
+      currentNoteIndex: "2",
       storageSchemaVersion: 2
     };
     mockInjectedStorage.getItem.mockResolvedValue(JSON.stringify(validState));
@@ -141,6 +123,7 @@ describe("createStorage", () => {
       balance: 1000n,
       idHash: 12345n,
       currentNote: 67890n,
+      currentNoteIndex: 2n,
       storageSchemaVersion: 2
     });
   });
@@ -168,6 +151,7 @@ describe("createStorage", () => {
       balance: 1000n,
       idHash: 12345n,
       currentNote: 67890n,
+      currentNoteIndex: 2n,
       storageSchemaVersion: 2
     };
 
@@ -180,6 +164,7 @@ describe("createStorage", () => {
         balance: "1000",
         idHash: "12345",
         currentNote: "67890",
+        currentNoteIndex: "2",
         storageSchemaVersion: 2
       })
     );

--- a/ts/shielder-sdk/__tests/utils.test.ts
+++ b/ts/shielder-sdk/__tests/utils.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "vitest";
 import { scalarToBigint } from "@cardinal-cryptography/shielder-sdk-crypto";
 import {
   flatUint8,
+  getAddressByToken,
   idHidingNonce,
   isVersionSupported,
   noteVersion
@@ -39,4 +40,16 @@ test("note version", () => {
 test("isVersionSupported", () => {
   expect(isVersionSupported("0x000100")).toBe(true);
   expect(isVersionSupported("0x000002")).toBe(false);
+});
+
+const nativeTokenAddress = "0x0000000000000000000000000000000000000000";
+
+test("getAddressByToken", () => {
+  expect(getAddressByToken({ type: "native" })).toBe(nativeTokenAddress);
+  expect(getAddressByToken({ type: "erc20", address: "0x123" })).toBe("0x123");
+});
+
+test("getTokenByAddress", () => {
+  expect(getAddressByToken({ type: "native" })).toBe(nativeTokenAddress);
+  expect(getAddressByToken({ type: "erc20", address: "0x123" })).toBe("0x123");
 });

--- a/ts/shielder-sdk/src/actions/deposit.ts
+++ b/ts/shielder-sdk/src/actions/deposit.ts
@@ -1,4 +1,4 @@
-import { IContract, VersionRejectedByContract } from "@/chain/contract";
+import { IContract } from "@/chain/contract";
 import {
   CryptoClient,
   DepositAdvice,
@@ -12,7 +12,9 @@ import { Calldata } from "@/actions";
 import { INonceGenerator, NoteAction } from "@/actions/utils";
 import { AccountState } from "@/state";
 import { Token } from "@/types";
-import { getTokenAddress } from "@/utils";
+import { getAddressByToken } from "@/utils";
+import { OutdatedSdkError } from "@/errors";
+import { AccountStateMerkleIndexed } from "@/state/types";
 
 export interface DepositCalldata extends Calldata {
   calldata: {
@@ -57,18 +59,15 @@ export class DepositAction extends NoteAction {
   }
 
   async prepareAdvice(
-    state: AccountState,
+    state: AccountStateMerkleIndexed,
     amount: bigint
   ): Promise<DepositAdvice<Scalar>> {
-    if (state.currentNoteIndex === undefined) {
-      throw new Error("currentNoteIndex must be set");
-    }
     const lastNodeIndex = state.currentNoteIndex;
     const [merklePath] = await this.merklePathAndRoot(
       await this.contract.getMerklePath(lastNodeIndex)
     );
 
-    const tokenAddress = getTokenAddress(state.token);
+    const tokenAddress = getAddressByToken(state.token);
 
     const nonce = this.nonceGenerator.randomIdHidingNonce();
     const { nullifier: nullifierOld, trapdoor: trapdoorOld } =
@@ -103,7 +102,7 @@ export class DepositAction extends NoteAction {
    * @returns calldata for deposit action
    */
   async generateCalldata(
-    state: AccountState,
+    state: AccountStateMerkleIndexed,
     amount: bigint,
     expectedContractVersion: `0x${string}`
   ): Promise<DepositCalldata> {
@@ -183,7 +182,7 @@ export class DepositAction extends NoteAction {
       to: this.contract.getAddress(),
       value: calldata.token.type === "native" ? amount : 0n
     }).catch((e) => {
-      if (e instanceof VersionRejectedByContract) {
+      if (e instanceof OutdatedSdkError) {
         throw e;
       }
       throw new Error(`Failed to deposit: ${e}`);

--- a/ts/shielder-sdk/src/actions/utils.ts
+++ b/ts/shielder-sdk/src/actions/utils.ts
@@ -3,7 +3,7 @@ import {
   Scalar
 } from "@cardinal-cryptography/shielder-sdk-crypto";
 import { AccountState } from "@/state";
-import { getTokenAddress, noteVersion } from "@/utils";
+import { getAddressByToken, noteVersion } from "@/utils";
 import { bytesToHex } from "viem";
 
 export abstract class NoteAction {
@@ -16,7 +16,7 @@ export abstract class NoteAction {
     amount: bigint,
     balanceChange: (currentBalance: bigint, amount: bigint) => bigint
   ): Promise<AccountState | null> {
-    const tokenAddress = getTokenAddress(stateOld.token);
+    const tokenAddress = getAddressByToken(stateOld.token);
     const { nullifier: nullifierNew, trapdoor: trapdoorNew } =
       await this.cryptoClient.secretManager.getSecrets(
         stateOld.id,
@@ -46,7 +46,6 @@ export abstract class NoteAction {
       nonce: stateOld.nonce + 1n,
       balance: balanceNew,
       currentNote: noteNew,
-      storageSchemaVersion: stateOld.storageSchemaVersion,
       token: stateOld.token
     };
   }

--- a/ts/shielder-sdk/src/actions/withdraw.ts
+++ b/ts/shielder-sdk/src/actions/withdraw.ts
@@ -1,4 +1,4 @@
-import { IContract, VersionRejectedByContract } from "@/chain/contract";
+import { IContract } from "@/chain/contract";
 import {
   CryptoClient,
   Proof,
@@ -9,11 +9,13 @@ import {
 } from "@cardinal-cryptography/shielder-sdk-crypto";
 import { AccountState } from "@/state";
 import { Address, encodePacked, hexToBigInt, keccak256 } from "viem";
-import { IRelayer, VersionRejectedByRelayer } from "@/chain/relayer";
+import { IRelayer } from "@/chain/relayer";
 import { INonceGenerator, NoteAction } from "@/actions/utils";
 import { Token } from "@/types";
-import { getTokenAddress } from "@/utils";
+import { getAddressByToken } from "@/utils";
 import { SendShielderTransaction } from "@/client";
+import { OutdatedSdkError } from "@/errors";
+import { AccountStateMerkleIndexed } from "@/state/types";
 
 export interface WithdrawCalldata {
   expectedContractVersion: `0x${string}`;
@@ -94,22 +96,19 @@ export class WithdrawAction extends NoteAction {
   }
 
   async prepareAdvice(
-    state: AccountState,
+    state: AccountStateMerkleIndexed,
     amount: bigint,
     expectedContractVersion: `0x${string}`,
     withdrawalAddress: `0x${string}`,
     relayerAddress: `0x${string}`,
     totalFee: bigint
   ): Promise<WithdrawAdvice<Scalar>> {
-    if (state.currentNoteIndex === undefined) {
-      throw new Error("currentNoteIndex must be set");
-    }
     const lastNodeIndex = state.currentNoteIndex;
     const [merklePath] = await this.merklePathAndRoot(
       await this.contract.getMerklePath(lastNodeIndex)
     );
 
-    const tokenAddress = getTokenAddress(state.token);
+    const tokenAddress = getAddressByToken(state.token);
 
     const idHidingNonce = this.nonceGenerator.randomIdHidingNonce();
 
@@ -158,7 +157,7 @@ export class WithdrawAction extends NoteAction {
    * @returns calldata for withdrawal action
    */
   async generateCalldata(
-    state: AccountState,
+    state: AccountStateMerkleIndexed,
     amount: bigint,
     relayerAddress: Address,
     totalFee: bigint,
@@ -238,7 +237,7 @@ export class WithdrawAction extends NoteAction {
         scalarToBigint(pubInputs.macCommitment)
       )
       .catch((e) => {
-        if (e instanceof VersionRejectedByRelayer) {
+        if (e instanceof OutdatedSdkError) {
           throw e;
         }
         throw new Error(`Failed to withdraw: ${e}`);
@@ -295,7 +294,7 @@ export class WithdrawAction extends NoteAction {
       to: this.contract.getAddress(),
       value: 0n
     }).catch((e) => {
-      if (e instanceof VersionRejectedByContract) {
+      if (e instanceof OutdatedSdkError) {
         throw e;
       }
       throw new Error(`Failed to withdraw: ${e}`);

--- a/ts/shielder-sdk/src/chain/contract.ts
+++ b/ts/shielder-sdk/src/chain/contract.ts
@@ -1,4 +1,3 @@
-import { CustomError } from "ts-custom-error";
 import {
   Address,
   bytesToHex,
@@ -12,12 +11,7 @@ import { BaseError, ContractFunctionRevertedError } from "viem";
 
 import { abi } from "../_generated/abi";
 import { shieldActionGasLimit } from "@/constants";
-
-export class VersionRejectedByContract extends CustomError {
-  public constructor() {
-    super("Version rejected by contract");
-  }
-}
+import { OutdatedSdkError } from "@/errors";
 
 export async function handleWrongContractVersionError<T>(
   func: () => Promise<T>
@@ -34,7 +28,7 @@ export async function handleWrongContractVersionError<T>(
       if (revertError instanceof ContractFunctionRevertedError) {
         const errorName = revertError.data?.errorName ?? "";
         if (errorName === "WrongContractVersion") {
-          throw new VersionRejectedByContract();
+          throw new OutdatedSdkError("Version rejected by contract");
         }
       }
     }

--- a/ts/shielder-sdk/src/chain/relayer.ts
+++ b/ts/shielder-sdk/src/chain/relayer.ts
@@ -1,6 +1,6 @@
 import { feeAddressPath, feePath, relayPath } from "@/constants";
+import { OutdatedSdkError } from "@/errors";
 import { Token } from "@/types";
-import { CustomError } from "ts-custom-error";
 import { Address } from "viem";
 import { z } from "zod";
 
@@ -17,12 +17,6 @@ const quoteFeesResponseSchema = z.object({
 });
 
 export type QuoteFeesResponse = z.infer<typeof quoteFeesResponseSchema>;
-
-export class VersionRejectedByRelayer extends CustomError {
-  public constructor(message: string) {
-    super(`Version rejected by relayer: ${message}`);
-  }
-}
 
 export class GenericWithdrawError extends Error {
   constructor(message: string) {
@@ -108,7 +102,9 @@ export class Relayer implements IRelayer {
       const responseText = await response.text();
 
       if (responseText.startsWith('"Version mismatch:')) {
-        throw new VersionRejectedByRelayer(responseText);
+        throw new OutdatedSdkError(
+          `Version rejected by relayer: ${responseText}`
+        );
       }
 
       throw new GenericWithdrawError(`${responseText}`);

--- a/ts/shielder-sdk/src/client/client.ts
+++ b/ts/shielder-sdk/src/client/client.ts
@@ -1,11 +1,7 @@
 import { CryptoClient } from "@cardinal-cryptography/shielder-sdk-crypto";
 import { Address, createPublicClient, Hash, http, PublicClient } from "viem";
-import {
-  Contract,
-  IContract,
-  VersionRejectedByContract
-} from "@/chain/contract";
-import { IRelayer, Relayer, VersionRejectedByRelayer } from "@/chain/relayer";
+import { Contract, IContract } from "@/chain/contract";
+import { IRelayer, Relayer } from "@/chain/relayer";
 import {
   NewAccountAction,
   DepositAction,
@@ -21,11 +17,9 @@ import {
   ShielderTransaction,
   StateEventsFilter,
   StateManager,
-  StateSynchronizer,
-  UnexpectedVersionInEvent
+  StateSynchronizer
 } from "@/state";
 import {
-  OutdatedSdkError,
   QuotedFees,
   SendShielderTransaction,
   ShielderCallbacks,
@@ -170,25 +164,11 @@ export class ShielderClient {
    */
   async syncShielderToken(token: Token) {
     try {
-      return await this.handleVersionErrors(() => {
-        return this.stateSynchronizer.syncAccountState(token);
-      });
+      return await this.stateSynchronizer.syncAccountState(token);
     } catch (error) {
       this.callbacks.onError?.(error, "syncing", "sync");
       throw error;
     }
-  }
-
-  /**
-   * Syncs the whole shielder state with the blockchain.
-   * Emits callbacks for the newly synced transaction.
-   * Might have side effects, as it mutates the shielder state.
-   * For the fresh storage and existing account being imported, it goes through the whole
-   * shielder transactions history and updates the state, so it might be slow.
-   * @throws {OutdatedSdkError} if cannot sync state due to unsupported contract version
-   */
-  async syncShielderAllTokens() {
-    return Promise.reject(new Error("Not implemented"));
   }
 
   /**
@@ -212,29 +192,7 @@ export class ShielderClient {
   async *scanChainForTokenShielderTransactions(
     token: Token
   ): AsyncGenerator<ShielderTransaction, void, unknown> {
-    try {
-      for await (const transaction of this.stateSynchronizer.getShielderTransactions(
-        token
-      )) {
-        yield transaction;
-      }
-    } catch (error) {
-      // Rethrow to produce `OutdatedSdkError` if needed.
-      try {
-        throw this.wrapVersionErrors(error);
-      } catch (error) {
-        this.callbacks.onError?.(error, "syncing", "sync");
-        throw error;
-      }
-    }
-  }
-
-  /**
-   * Get the whole shielder transactions history for all tokens.
-   */
-  // eslint-disable-next-line require-yield
-  async *scanChainForAllShielderTransactions() {
-    return Promise.reject(new Error("Not implemented"));
+    yield* this.stateSynchronizer.getShielderTransactions(token);
   }
 
   /**
@@ -415,7 +373,7 @@ export class ShielderClient {
   ): Promise<Hash> {
     let calldata: T;
     try {
-      calldata = await this.handleVersionErrors(generateCalldata);
+      calldata = await generateCalldata();
     } catch (error) {
       this.callbacks.onError?.(error, "generation", operation);
       throw error;
@@ -423,9 +381,7 @@ export class ShielderClient {
     this.callbacks.onCalldataGenerated?.(calldata, operation);
 
     try {
-      const txHash = await this.handleVersionErrors(() => {
-        return sendCalldata(calldata);
-      });
+      const txHash = await sendCalldata(calldata);
       this.callbacks.onCalldataSent?.(txHash, operation);
       return txHash;
     } catch (error) {
@@ -433,25 +389,6 @@ export class ShielderClient {
       throw error;
     }
   }
-
-  private wrapVersionErrors(err: unknown) {
-    if (
-      err instanceof VersionRejectedByContract ||
-      err instanceof VersionRejectedByRelayer ||
-      err instanceof UnexpectedVersionInEvent
-    ) {
-      return new OutdatedSdkError();
-    }
-    return err;
-  }
-
-  private async handleVersionErrors<T>(func: () => Promise<T>): Promise<T> {
-    try {
-      return await func();
-    } catch (err) {
-      throw this.wrapVersionErrors(err);
-    }
-  }
 }
 
-export { SendShielderTransaction, OutdatedSdkError, ShielderCallbacks };
+export { SendShielderTransaction, ShielderCallbacks };

--- a/ts/shielder-sdk/src/client/index.ts
+++ b/ts/shielder-sdk/src/client/index.ts
@@ -1,5 +1,4 @@
 import {
-  OutdatedSdkError,
   QuotedFees,
   SendShielderTransaction,
   ShielderCallbacks,
@@ -10,7 +9,6 @@ export {
   ShielderClient,
   createShielderClient,
   SendShielderTransaction,
-  OutdatedSdkError,
   ShielderCallbacks,
   ShielderOperation,
   QuotedFees

--- a/ts/shielder-sdk/src/client/types.ts
+++ b/ts/shielder-sdk/src/client/types.ts
@@ -1,14 +1,7 @@
 import { Calldata } from "@/actions";
 import { ShielderTransaction } from "@/state";
-import { CustomError } from "ts-custom-error";
 
 export type ShielderOperation = "shield" | "withdraw" | "sync";
-
-export class OutdatedSdkError extends CustomError {
-  public constructor() {
-    super("Contract version not supported by SDK");
-  }
-}
 
 export interface ShielderCallbacks {
   /**

--- a/ts/shielder-sdk/src/errors.ts
+++ b/ts/shielder-sdk/src/errors.ts
@@ -1,0 +1,7 @@
+import { CustomError } from "ts-custom-error";
+
+export class OutdatedSdkError extends CustomError {
+  public constructor(message: string) {
+    super(message);
+  }
+}

--- a/ts/shielder-sdk/src/index.ts
+++ b/ts/shielder-sdk/src/index.ts
@@ -2,7 +2,6 @@ export {
   ShielderClient,
   createShielderClient,
   SendShielderTransaction,
-  OutdatedSdkError,
   ShielderCallbacks,
   QuotedFees,
   ShielderOperation
@@ -20,4 +19,5 @@ export {
   nativeToken,
   erc20Token
 } from "@/types";
+export { OutdatedSdkError } from "@/errors";
 export { shieldActionGasLimit } from "@/constants";

--- a/ts/shielder-sdk/src/state/events.ts
+++ b/ts/shielder-sdk/src/state/events.ts
@@ -4,6 +4,7 @@ import { NewAccountAction } from "@/actions/newAccount";
 import { WithdrawAction } from "@/actions/withdraw";
 import { NoteEvent } from "@/chain/contract";
 import { scalarToBigint } from "@cardinal-cryptography/shielder-sdk-crypto";
+import { AccountStateMerkleIndexed } from "./types";
 
 export class StateEventsFilter {
   newAccountAction: NewAccountAction;
@@ -22,7 +23,7 @@ export class StateEventsFilter {
   newStateByEvent = async (
     state: AccountState,
     noteEvent: NoteEvent
-  ): Promise<AccountState | null> => {
+  ): Promise<AccountStateMerkleIndexed | null> => {
     const getNewState = async () => {
       switch (noteEvent.name) {
         case "NewAccount":

--- a/ts/shielder-sdk/src/state/index.ts
+++ b/ts/shielder-sdk/src/state/index.ts
@@ -1,5 +1,5 @@
 import { StateManager } from "./manager";
-import { StateSynchronizer, UnexpectedVersionInEvent } from "./sync";
+import { StateSynchronizer } from "./sync";
 import { StateEventsFilter } from "./events";
 import accountObjectSchema, {
   InjectedStorageInterface,
@@ -15,6 +15,5 @@ export {
   ShielderTransaction,
   StateManager,
   StateSynchronizer,
-  StateEventsFilter,
-  UnexpectedVersionInEvent
+  StateEventsFilter
 };

--- a/ts/shielder-sdk/src/state/storageSchema.ts
+++ b/ts/shielder-sdk/src/state/storageSchema.ts
@@ -18,7 +18,7 @@ const accountObjectSchema = z.object({
   balance: validateBigInt,
   idHash: validateBigInt,
   currentNote: validateBigInt,
-  currentNoteIndex: z.union([validateBigInt, z.undefined()]).optional(),
+  currentNoteIndex: validateBigInt,
   storageSchemaVersion: z.number()
 });
 

--- a/ts/shielder-sdk/src/state/types.ts
+++ b/ts/shielder-sdk/src/state/types.ts
@@ -23,14 +23,13 @@ export type AccountState = {
    * Hash of the last note.
    */
   currentNote: Scalar;
+};
+
+export type AccountStateMerkleIndexed = AccountState & {
   /**
    * Merkle tree index of the last note.
    */
-  currentNoteIndex?: bigint;
-  /**
-   * Version of the storage schema.
-   */
-  storageSchemaVersion: number;
+  currentNoteIndex: bigint;
 };
 
 export type ShielderTransaction = {

--- a/ts/shielder-sdk/src/utils.ts
+++ b/ts/shielder-sdk/src/utils.ts
@@ -1,6 +1,6 @@
 import { Scalar } from "@cardinal-cryptography/shielder-sdk-crypto";
 import { contractVersion, nativeTokenAddress } from "@/constants";
-import { Token } from "./types";
+import { erc20Token, nativeToken, Token } from "./types";
 
 export function flatUint8(arr: Uint8Array[]) {
   return new Uint8Array(
@@ -27,6 +27,12 @@ export function isVersionSupported(version: `0x${string}`) {
   return version === contractVersion;
 }
 
-export function getTokenAddress(token: Token): `0x${string}` {
+export function getAddressByToken(token: Token): `0x${string}` {
   return token.type === "native" ? nativeTokenAddress : token.address;
+}
+
+export function getTokenByAddress(tokenAddress: `0x${string}`): Token {
+  return tokenAddress === nativeTokenAddress
+    ? nativeToken()
+    : erc20Token(tokenAddress);
 }

--- a/ts/shielder-sdk/src/utils.ts
+++ b/ts/shielder-sdk/src/utils.ts
@@ -27,10 +27,20 @@ export function isVersionSupported(version: `0x${string}`) {
   return version === contractVersion;
 }
 
+/**
+ * Returns the address of a given token
+ * @param token - The token object (either native or ERC20)
+ * @returns The hexadecimal address of the token
+ */
 export function getAddressByToken(token: Token): `0x${string}` {
   return token.type === "native" ? nativeTokenAddress : token.address;
 }
 
+/**
+ * Creates a Token object from a given address
+ * @param tokenAddress - The hexadecimal address of the token
+ * @returns A Token object (either native or ERC20 depending on the address)
+ */
 export function getTokenByAddress(tokenAddress: `0x${string}`): Token {
   return tokenAddress === nativeTokenAddress
     ? nativeToken()


### PR DESCRIPTION
- removing all intermediate version exceptions to use `OutdatedSdkError`, thus removing redundant error re-throwing.
- removing optional field `currentNoteIndex` from `AccountState` object, creating strongly-typed `AccountStateMerkleIndexed`.
- removing `storageSchemaVersion` from `AccountState` object, thus leaving responsibility of storage versioning fully in `StateManager`
- some small renamings
- test changes