### PR TITLE
Relayer: improve token config

### DIFF
--- a/crates/shielder-cli/src/shielder_ops/withdraw.rs
+++ b/crates/shielder-cli/src/shielder_ops/withdraw.rs
@@ -11,7 +11,7 @@ use shielder_account::{
 use shielder_contract::{
     events::get_event, merkle_path::get_current_merkle_path, ShielderContract::Withdraw,
 };
-use shielder_relayer::{TokenKind, QuoteFeeResponse, RelayQuery, RelayResponse};
+use shielder_relayer::{QuoteFeeResponse, RelayQuery, RelayResponse, TokenKind};
 use shielder_setup::version::contract_version;
 use tokio::time::sleep;
 use tracing::{debug, info};

--- a/crates/shielder-cli/src/shielder_ops/withdraw.rs
+++ b/crates/shielder-cli/src/shielder_ops/withdraw.rs
@@ -11,7 +11,7 @@ use shielder_account::{
 use shielder_contract::{
     events::get_event, merkle_path::get_current_merkle_path, ShielderContract::Withdraw,
 };
-use shielder_relayer::{FeeToken, QuoteFeeResponse, RelayQuery, RelayResponse};
+use shielder_relayer::{TokenKind, QuoteFeeResponse, RelayQuery, RelayResponse};
 use shielder_setup::version::contract_version;
 use tokio::time::sleep;
 use tracing::{debug, info};
@@ -155,7 +155,7 @@ async fn prepare_relayer_query(
         nullifier_hash: calldata.oldNullifierHash,
         new_note: calldata.newNote,
         proof: calldata.proof,
-        fee_token: FeeToken::Native,
+        fee_token: TokenKind::Native,
         fee_amount: calldata.relayerFee,
         mac_salt: calldata.macSalt,
         mac_commitment: calldata.macCommitment,

--- a/crates/shielder-relayer/run-relayer.sh
+++ b/crates/shielder-relayer/run-relayer.sh
@@ -70,8 +70,8 @@ fi
 if [[ -n "${PRICE_FEED_REFRESH_INTERVAL:-}" ]]; then
   ARGS+=(-e PRICE_FEED_REFRESH_INTERVAL="${PRICE_FEED_REFRESH_INTERVAL}")
 fi
-if [[ -n "${TOKEN_PRICING:-}" ]]; then
-  ARGS+=(-e TOKEN_PRICING="${TOKEN_PRICING}")
+if [[ -n "${TOKEN_CONFIG:-}" ]]; then
+  ARGS+=(-e TOKEN_CONFIG="${TOKEN_CONFIG}")
 fi
 if [[ -n "${NATIVE_TOKEN:-}" ]]; then
   ARGS+=(-e NATIVE_TOKEN="${NATIVE_TOKEN}")

--- a/crates/shielder-relayer/src/config/cli.rs
+++ b/crates/shielder-relayer/src/config/cli.rs
@@ -152,7 +152,7 @@ pub struct CLIConfig {
             [{\"coin\":\"Eth\", \"kind\":\"Native\", \"pricing\":{\"Fixed\":{\"price\":\"12.3\"}}}] \
             \
             This example configure a token to use the `Usdc` price feed for its pricing: \
-            [{\"coin\":\"Usdc\", \"kind\":{\"ERC20\":\"0x6b175474e89094c44da98b954eedeac495271d0f\"},\"pricing\":{\"Feed\":{\"price_feed_coin\":\"Usdc\"}}}]
+            [{\"coin\":\"Usdc\", \"kind\":{\"ERC20\":\"0x6b175474e89094c44da98b954eedeac495271d0f\"},\"pricing\":\"Feed\"}]
             "
     )]
     pub token_config: Option<String>,

--- a/crates/shielder-relayer/src/config/cli.rs
+++ b/crates/shielder-relayer/src/config/cli.rs
@@ -149,10 +149,10 @@ pub struct CLIConfig {
             If that is not set, assumed to be empty. Parsed as JSON: \
             \
             This example configures a token to have a constant price of 12.3 USD: \
-            [{\"kind\":\"Native\", \"pricing\":{\"Fixed\":{\"price\":\"12.3\"}}}] \
+            [{\"coin\":\"Eth\", \"kind\":\"Native\", \"pricing\":{\"Fixed\":{\"price\":\"12.3\"}}}] \
             \
             This example configure a token to use the `Usdc` price feed for its pricing: \
-            [{\"kind\":{\"ERC20\":\"0x6b175474e89094c44da98b954eedeac495271d0f\"},\"pricing\":{\"Feed\":{\"price_feed_coin\":\"Usdc\"}}}]
+            [{\"coin\":\"Usdc\", \"kind\":{\"ERC20\":\"0x6b175474e89094c44da98b954eedeac495271d0f\"},\"pricing\":{\"Feed\":{\"price_feed_coin\":\"Usdc\"}}}]
             "
     )]
     pub token_config: Option<String>,

--- a/crates/shielder-relayer/src/config/cli.rs
+++ b/crates/shielder-relayer/src/config/cli.rs
@@ -145,17 +145,17 @@ pub struct CLIConfig {
         long,
         help = "Token pricing configuration for tokens that are qualified as a fee token.",
         long_help = "Token pricing configuration for tokens that are qualified as a fee token. \
-            If not provided, the value from the environment variable `{TOKEN_PRICING_ENV}` will be used. \
+            If not provided, the value from the environment variable `{TOKEN_CONFIG_ENV}` will be used. \
             If that is not set, assumed to be empty. Parsed as JSON: \
             \
             This example configures a token to have a constant price of 12.3 USD: \
-            [{\"token\":\"Native\", \"pricing\":{\"Fixed\":{\"price\":\"12.3\"}}}] \
+            [{\"kind\":\"Native\", \"pricing\":{\"Fixed\":{\"price\":\"12.3\"}}}] \
             \
             This example configure a token to use the `Usdc` price feed for its pricing: \
-            [{\"token\":{\"ERC20\":\"0x6b175474e89094c44da98b954eedeac495271d0f\"},\"pricing\":{\"Feed\":{\"price_feed_coin\":\"Usdc\"}}}]
+            [{\"kind\":{\"ERC20\":\"0x6b175474e89094c44da98b954eedeac495271d0f\"},\"pricing\":{\"Feed\":{\"price_feed_coin\":\"Usdc\"}}}]
             "
     )]
-    pub token_pricing: Option<String>,
+    pub token_config: Option<String>,
 
     #[clap(
         long,

--- a/crates/shielder-relayer/src/config/mod.rs
+++ b/crates/shielder-relayer/src/config/mod.rs
@@ -61,7 +61,7 @@ pub struct ChainConfig {
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub enum Pricing {
     Fixed { price: Decimal },
-    Feed { price_feed_coin: Coin },
+    Feed,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]

--- a/crates/shielder-relayer/src/config/mod.rs
+++ b/crates/shielder-relayer/src/config/mod.rs
@@ -12,7 +12,7 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use shielder_contract::alloy_primitives::{Address, U256};
 use shielder_relayer::{
-    Coin, FeeToken, BALANCE_MONITOR_INTERVAL_SECS_ENV, DRY_RUNNING_ENV, FEE_DESTINATION_KEY_ENV,
+    Coin, TokenKind, BALANCE_MONITOR_INTERVAL_SECS_ENV, DRY_RUNNING_ENV, FEE_DESTINATION_KEY_ENV,
     LOGGING_FORMAT_ENV, NATIVE_TOKEN_ENV, NODE_RPC_URL_ENV, NONCE_POLICY_ENV,
     PRICE_FEED_REFRESH_INTERVAL_ENV, PRICE_FEED_VALIDITY_ENV, RELAYER_HOST_ENV,
     RELAYER_METRICS_PORT_ENV, RELAYER_PORT_ENV, RELAYER_SIGNING_KEYS_ENV,
@@ -66,7 +66,7 @@ pub enum Pricing {
 
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct TokenPricingConfig {
-    pub token: FeeToken,
+    pub token: TokenKind,
     pub pricing: Pricing,
 }
 

--- a/crates/shielder-relayer/src/config/mod.rs
+++ b/crates/shielder-relayer/src/config/mod.rs
@@ -16,7 +16,7 @@ use shielder_relayer::{
     LOGGING_FORMAT_ENV, NATIVE_TOKEN_ENV, NODE_RPC_URL_ENV, NONCE_POLICY_ENV,
     PRICE_FEED_REFRESH_INTERVAL_ENV, PRICE_FEED_VALIDITY_ENV, RELAYER_HOST_ENV,
     RELAYER_METRICS_PORT_ENV, RELAYER_PORT_ENV, RELAYER_SIGNING_KEYS_ENV,
-    RELAY_COUNT_FOR_RECHARGE_ENV, RELAY_GAS_ENV, SHIELDER_CONTRACT_ADDRESS_ENV, TOKEN_PRICING_ENV,
+    RELAY_COUNT_FOR_RECHARGE_ENV, RELAY_GAS_ENV, SHIELDER_CONTRACT_ADDRESS_ENV, TOKEN_CONFIG_ENV,
     TOTAL_FEE_ENV,
 };
 
@@ -65,8 +65,8 @@ pub enum Pricing {
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
-pub struct TokenPricingConfig {
-    pub token: TokenKind,
+pub struct TokenConfig {
+    pub kind: TokenKind,
     pub pricing: Pricing,
 }
 
@@ -76,7 +76,7 @@ pub struct OperationalConfig {
     pub nonce_policy: NoncePolicy,
     pub dry_running: DryRunning,
     pub relay_count_for_recharge: u32,
-    pub token_pricing: Vec<TokenPricingConfig>,
+    pub token_config: Vec<TokenConfig>,
     pub price_feed_validity: u64,
     pub price_feed_refresh_interval: u64,
 }
@@ -117,7 +117,7 @@ fn resolve_config_from_cli_config(
         relay_count_for_recharge,
         total_fee,
         relay_gas,
-        token_pricing,
+        token_config,
         price_feed_validity,
         price_feed_refresh_interval,
         native_token,
@@ -162,10 +162,10 @@ fn resolve_config_from_cli_config(
         native_token: resolve_value(native_token, NATIVE_TOKEN_ENV, None),
     };
 
-    let token_pricing = token_pricing
-        .or_else(|| std::env::var(TOKEN_PRICING_ENV).ok())
+    let token_config = token_config
+        .or_else(|| std::env::var(TOKEN_CONFIG_ENV).ok())
         .unwrap_or_else(|| "[]".to_string());
-    let token_pricing = serde_json::from_str(&token_pricing).expect("Invalid token pricing");
+    let token_config = serde_json::from_str(&token_config).expect("Invalid token pricing");
 
     let operational_config = OperationalConfig {
         balance_monitor_interval_secs: resolve_value(
@@ -180,7 +180,7 @@ fn resolve_config_from_cli_config(
             RELAY_COUNT_FOR_RECHARGE_ENV,
             Some(DEFAULT_RELAY_COUNT_FOR_RECHARGE),
         ),
-        token_pricing,
+        token_config,
         price_feed_validity: resolve_value(
             price_feed_validity,
             PRICE_FEED_VALIDITY_ENV,

--- a/crates/shielder-relayer/src/config/mod.rs
+++ b/crates/shielder-relayer/src/config/mod.rs
@@ -66,6 +66,7 @@ pub enum Pricing {
 
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct TokenConfig {
+    pub coin: Coin,
     pub kind: TokenKind,
     pub pricing: Pricing,
 }

--- a/crates/shielder-relayer/src/config/tests.rs
+++ b/crates/shielder-relayer/src/config/tests.rs
@@ -40,9 +40,7 @@ fn config_resolution() {
         TokenConfig {
             coin: Coin::Eth,
             kind: TokenKind::ERC20(address!("2222222222222222222222222222222222222222")),
-            pricing: Pricing::Feed {
-                price_feed_coin: Coin::Eth,
-            },
+            pricing: Pricing::Feed,
         },
     ];
     let price_feed_refresh_interval = DEFAULT_PRICE_FEED_REFRESH_INTERVAL_SECS;
@@ -65,13 +63,13 @@ fn config_resolution() {
             native_token,                                     // from env
         },
         operations: OperationalConfig {
-            balance_monitor_interval_secs,  // from env
-            nonce_policy,                   // default
-            dry_running,                    // from CLI
-            relay_count_for_recharge,       // default
-            token_config,                   // from env
-            price_feed_refresh_interval,    // default
-            price_feed_validity,            // from CLI
+            balance_monitor_interval_secs, // from env
+            nonce_policy,                  // default
+            dry_running,                   // from CLI
+            relay_count_for_recharge,      // default
+            token_config,                  // from env
+            price_feed_refresh_interval,   // default
+            price_feed_validity,           // from CLI
         },
     };
 
@@ -118,7 +116,7 @@ fn config_resolution() {
                 {
                     \"coin\":\"Eth\",
                     \"kind\":{\"ERC20\":\"0x2222222222222222222222222222222222222222\"},
-                    \"pricing\":{\"Feed\":{\"price_feed_coin\":\"Eth\"}}
+                    \"pricing\":\"Feed\"
                 }
             ]",
         );

--- a/crates/shielder-relayer/src/config/tests.rs
+++ b/crates/shielder-relayer/src/config/tests.rs
@@ -30,13 +30,13 @@ fn config_resolution() {
     let relay_gas: u64 = DEFAULT_RELAY_GAS + 1;
     let fee_token_config = vec![
         TokenPricingConfig {
-            token: FeeToken::Native,
+            token: TokenKind::Native,
             pricing: Pricing::Fixed {
                 price: Decimal::from_str("1.23").unwrap(),
             },
         },
         TokenPricingConfig {
-            token: FeeToken::ERC20(address!("2222222222222222222222222222222222222222")),
+            token: TokenKind::ERC20(address!("2222222222222222222222222222222222222222")),
             pricing: Pricing::Feed {
                 price_feed_coin: Coin::Eth,
             },

--- a/crates/shielder-relayer/src/config/tests.rs
+++ b/crates/shielder-relayer/src/config/tests.rs
@@ -28,15 +28,15 @@ fn config_resolution() {
     let relay_count_for_recharge = DEFAULT_RELAY_COUNT_FOR_RECHARGE;
     let total_fee = DEFAULT_TOTAL_FEE.to_string();
     let relay_gas: u64 = DEFAULT_RELAY_GAS + 1;
-    let fee_token_config = vec![
-        TokenPricingConfig {
-            token: TokenKind::Native,
+    let token_config = vec![
+        TokenConfig {
+            kind: TokenKind::Native,
             pricing: Pricing::Fixed {
                 price: Decimal::from_str("1.23").unwrap(),
             },
         },
-        TokenPricingConfig {
-            token: TokenKind::ERC20(address!("2222222222222222222222222222222222222222")),
+        TokenConfig {
+            kind: TokenKind::ERC20(address!("2222222222222222222222222222222222222222")),
             pricing: Pricing::Feed {
                 price_feed_coin: Coin::Eth,
             },
@@ -63,13 +63,13 @@ fn config_resolution() {
             native_token,                                     // from env
         },
         operations: OperationalConfig {
-            balance_monitor_interval_secs,   // from env
-            nonce_policy,                    // default
-            dry_running,                     // from CLI
-            relay_count_for_recharge,        // default
-            token_pricing: fee_token_config, // from env
-            price_feed_refresh_interval,     // default
-            price_feed_validity,             // from CLI
+            balance_monitor_interval_secs,  // from env
+            nonce_policy,                   // default
+            dry_running,                    // from CLI
+            relay_count_for_recharge,       // default
+            token_config,                   // from env
+            price_feed_refresh_interval,    // default
+            price_feed_validity,            // from CLI
         },
     };
 
@@ -89,7 +89,7 @@ fn config_resolution() {
         relay_count_for_recharge: None,
         total_fee: Some(total_fee),
         relay_gas: None,
-        token_pricing: None,
+        token_config: None,
         price_feed_refresh_interval: None,
         price_feed_validity: Some(price_feed_validity),
         native_token: None,
@@ -106,14 +106,14 @@ fn config_resolution() {
         std::env::set_var(RELAYER_SIGNING_KEYS_ENV, format!("{key1},{key2}"));
         std::env::set_var(RELAY_GAS_ENV, relay_gas.to_string());
         std::env::set_var(
-            TOKEN_PRICING_ENV,
+            TOKEN_CONFIG_ENV,
             "[
                 {
-                    \"token\":\"Native\",
+                    \"kind\":\"Native\",
                     \"pricing\":{\"Fixed\":{\"price\":\"1.23\"}}
                 },
                 {
-                    \"token\":{\"ERC20\":\"0x2222222222222222222222222222222222222222\"},
+                    \"kind\":{\"ERC20\":\"0x2222222222222222222222222222222222222222\"},
                     \"pricing\":{\"Feed\":{\"price_feed_coin\":\"Eth\"}}
                 }
             ]",

--- a/crates/shielder-relayer/src/config/tests.rs
+++ b/crates/shielder-relayer/src/config/tests.rs
@@ -28,14 +28,17 @@ fn config_resolution() {
     let relay_count_for_recharge = DEFAULT_RELAY_COUNT_FOR_RECHARGE;
     let total_fee = DEFAULT_TOTAL_FEE.to_string();
     let relay_gas: u64 = DEFAULT_RELAY_GAS + 1;
+    let native_token = Coin::Btc;
     let token_config = vec![
         TokenConfig {
+            coin: native_token,
             kind: TokenKind::Native,
             pricing: Pricing::Fixed {
                 price: Decimal::from_str("1.23").unwrap(),
             },
         },
         TokenConfig {
+            coin: Coin::Eth,
             kind: TokenKind::ERC20(address!("2222222222222222222222222222222222222222")),
             pricing: Pricing::Feed {
                 price_feed_coin: Coin::Eth,
@@ -44,7 +47,6 @@ fn config_resolution() {
     ];
     let price_feed_refresh_interval = DEFAULT_PRICE_FEED_REFRESH_INTERVAL_SECS;
     let price_feed_validity = 15;
-    let native_token = Coin::Btc;
 
     let expected_config = ServerConfig {
         logging_format, // from CLI
@@ -109,10 +111,12 @@ fn config_resolution() {
             TOKEN_CONFIG_ENV,
             "[
                 {
+                    \"coin\":\"Btc\",
                     \"kind\":\"Native\",
                     \"pricing\":{\"Fixed\":{\"price\":\"1.23\"}}
                 },
                 {
+                    \"coin\":\"Eth\",
                     \"kind\":{\"ERC20\":\"0x2222222222222222222222222222222222222222\"},
                     \"pricing\":{\"Feed\":{\"price_feed_coin\":\"Eth\"}}
                 }

--- a/crates/shielder-relayer/src/lib.rs
+++ b/crates/shielder-relayer/src/lib.rs
@@ -84,14 +84,14 @@ pub struct RelayQuery {
     pub nullifier_hash: U256,
     pub new_note: U256,
     pub proof: Bytes,
-    pub fee_token: FeeToken,
+    pub fee_token: TokenKind,
     pub fee_amount: U256,
     pub mac_salt: U256,
     pub mac_commitment: U256,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
-pub enum FeeToken {
+pub enum TokenKind {
     #[default]
     Native,
     ERC20(Address),

--- a/crates/shielder-relayer/src/lib.rs
+++ b/crates/shielder-relayer/src/lib.rs
@@ -26,7 +26,7 @@ pub const TOTAL_FEE_ENV: &str = "TOTAL_FEE";
 pub const RELAY_GAS_ENV: &str = "RELAY_GAS";
 pub const PRICE_FEED_VALIDITY_ENV: &str = "PRICE_FEED_VALIDITY";
 pub const PRICE_FEED_REFRESH_INTERVAL_ENV: &str = "PRICE_FEED_REFRESH_INTERVAL";
-pub const TOKEN_PRICING_ENV: &str = "TOKEN_PRICING";
+pub const TOKEN_CONFIG_ENV: &str = "TOKEN_CONFIG";
 pub const NATIVE_TOKEN_ENV: &str = "NATIVE_TOKEN";
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/shielder-relayer/src/main.rs
+++ b/crates/shielder-relayer/src/main.rs
@@ -10,7 +10,7 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use config::TokenPricingConfig;
+use config::TokenConfig;
 use price_feed::{start_price_feed, Prices};
 use shielder_contract::{
     alloy_primitives::{Address, U256},
@@ -49,7 +49,7 @@ pub struct AppState {
     pub taskmaster: Taskmaster,
     pub balances: Balances,
     pub prices: Prices,
-    pub token_pricing: Vec<TokenPricingConfig>,
+    pub token_config: Vec<TokenConfig>,
     pub native_token: Coin,
 }
 
@@ -149,7 +149,7 @@ async fn start_main_server(config: &ServerConfig, signers: Signers, prices: Pric
             config.operations.dry_running,
             report_for_recharge,
         ),
-        token_pricing: config.operations.token_pricing.clone(),
+        token_config: config.operations.token_config.clone(),
         prices,
         native_token: config.chain.native_token,
     };

--- a/crates/shielder-relayer/src/relay/fee_checking_tests.rs
+++ b/crates/shielder-relayer/src/relay/fee_checking_tests.rs
@@ -95,6 +95,7 @@ mod erc20_fee {
 
     fn erc20_pricing() -> TokenConfig {
         TokenConfig {
+            coin: Coin::Eth,
             kind: TokenKind::ERC20(ERC20_ADDRESS),
             pricing: Pricing::Feed {
                 price_feed_coin: Coin::Eth,
@@ -104,6 +105,7 @@ mod erc20_fee {
 
     fn native_pricing() -> TokenConfig {
         TokenConfig {
+            coin: Coin::Azero,
             kind: TokenKind::Native,
             pricing: Pricing::Feed {
                 price_feed_coin: Coin::Azero,
@@ -223,7 +225,7 @@ mod erc20_fee {
         let app_state = app_state();
         app_state.prices.set_price(Coin::Eth, Decimal::new(15, 1));
         // there is no way of checking AZERO price (we don't configure background
-        // price fetching nor we set the price manually)
+        // price fetching, nor we set the price manually)
 
         let query = RelayQuery {
             fee_amount: U256::from(200),
@@ -243,6 +245,7 @@ mod erc20_fee {
             token_config: vec![
                 erc20_pricing(),
                 TokenConfig {
+                    coin: Coin::Btc,
                     kind: TokenKind::Native,
                     pricing: Pricing::Feed {
                         price_feed_coin: Coin::Btc,

--- a/crates/shielder-relayer/src/relay/fee_checking_tests.rs
+++ b/crates/shielder-relayer/src/relay/fee_checking_tests.rs
@@ -97,9 +97,7 @@ mod erc20_fee {
         TokenConfig {
             coin: Coin::Eth,
             kind: TokenKind::ERC20(ERC20_ADDRESS),
-            pricing: Pricing::Feed {
-                price_feed_coin: Coin::Eth,
-            },
+            pricing: Pricing::Feed,
         }
     }
 
@@ -107,9 +105,7 @@ mod erc20_fee {
         TokenConfig {
             coin: Coin::Azero,
             kind: TokenKind::Native,
-            pricing: Pricing::Feed {
-                price_feed_coin: Coin::Azero,
-            },
+            pricing: Pricing::Feed,
         }
     }
 
@@ -247,9 +243,7 @@ mod erc20_fee {
                 TokenConfig {
                     coin: Coin::Btc,
                     kind: TokenKind::Native,
-                    pricing: Pricing::Feed {
-                        price_feed_coin: Coin::Btc,
-                    },
+                    pricing: Pricing::Feed,
                 },
             ],
             ..app_state()

--- a/crates/shielder-relayer/src/relay/fee_checking_tests.rs
+++ b/crates/shielder-relayer/src/relay/fee_checking_tests.rs
@@ -40,7 +40,7 @@ mod native_fee {
     fn too_low_fee_fails() {
         let query = RelayQuery {
             fee_amount: U256::from(80),
-            fee_token: FeeToken::Native,
+            fee_token: TokenKind::Native,
             ..Default::default()
         };
         let mut request_trace = RequestTrace::new(&query);
@@ -52,7 +52,7 @@ mod native_fee {
     fn low_fee_but_within_margin_fails() {
         let query = RelayQuery {
             fee_amount: U256::from(99),
-            fee_token: FeeToken::Native,
+            fee_token: TokenKind::Native,
             ..Default::default()
         };
         let mut request_trace = RequestTrace::new(&query);
@@ -64,7 +64,7 @@ mod native_fee {
     fn exact_fee_passes() {
         let query = RelayQuery {
             fee_amount: U256::from(100),
-            fee_token: FeeToken::Native,
+            fee_token: TokenKind::Native,
             ..Default::default()
         };
         let mut request_trace = RequestTrace::new(&query);
@@ -76,7 +76,7 @@ mod native_fee {
     fn way_too_high_fee_passes() {
         let query = RelayQuery {
             fee_amount: U256::from(1000000),
-            fee_token: FeeToken::Native,
+            fee_token: TokenKind::Native,
             ..Default::default()
         };
         let mut request_trace = RequestTrace::new(&query);
@@ -95,7 +95,7 @@ mod erc20_fee {
 
     fn erc20_pricing() -> TokenPricingConfig {
         TokenPricingConfig {
-            token: FeeToken::ERC20(ERC20_ADDRESS),
+            token: TokenKind::ERC20(ERC20_ADDRESS),
             pricing: Pricing::Feed {
                 price_feed_coin: Coin::Eth,
             },
@@ -104,7 +104,7 @@ mod erc20_fee {
 
     fn native_pricing() -> TokenPricingConfig {
         TokenPricingConfig {
-            token: FeeToken::Native,
+            token: TokenKind::Native,
             pricing: Pricing::Feed {
                 price_feed_coin: Coin::Azero,
             },
@@ -121,7 +121,7 @@ mod erc20_fee {
         app_state.prices.set_price(Coin::Azero, Decimal::new(4, 0));
 
         let query = RelayQuery {
-            fee_token: FeeToken::ERC20(ERC20_ADDRESS),
+            fee_token: TokenKind::ERC20(ERC20_ADDRESS),
             fee_amount: U256::from(100000000),
             ..RelayQuery::default()
         };
@@ -157,7 +157,7 @@ mod erc20_fee {
     fn exact_fee_passes() {
         let query = RelayQuery {
             fee_amount: U256::from(200), // total fee is AZERO 100, which is worth $300
-            fee_token: FeeToken::ERC20(ERC20_ADDRESS),
+            fee_token: TokenKind::ERC20(ERC20_ADDRESS),
             ..RelayQuery::default()
         };
         let mut request_trace = RequestTrace::new(&query);
@@ -170,7 +170,7 @@ mod erc20_fee {
     fn too_low_fee_fails() {
         let query = RelayQuery {
             fee_amount: U256::from(20), // total fee is AZERO 100, which is worth $300
-            fee_token: FeeToken::ERC20(ERC20_ADDRESS),
+            fee_token: TokenKind::ERC20(ERC20_ADDRESS),
             ..RelayQuery::default()
         };
         let mut request_trace = RequestTrace::new(&query);
@@ -183,7 +183,7 @@ mod erc20_fee {
     fn low_fee_but_within_margin_passes() {
         let query = RelayQuery {
             fee_amount: U256::from(199), // total fee is AZERO 100, which is worth $300
-            fee_token: FeeToken::ERC20(ERC20_ADDRESS),
+            fee_token: TokenKind::ERC20(ERC20_ADDRESS),
             ..RelayQuery::default()
         };
         let mut request_trace = RequestTrace::new(&query);
@@ -196,7 +196,7 @@ mod erc20_fee {
     fn way_too_high_fee_passes() {
         let query = RelayQuery {
             fee_amount: U256::from(200000),
-            fee_token: FeeToken::ERC20(ERC20_ADDRESS),
+            fee_token: TokenKind::ERC20(ERC20_ADDRESS),
             ..RelayQuery::default()
         };
         let mut request_trace = RequestTrace::new(&query);
@@ -209,7 +209,7 @@ mod erc20_fee {
     fn unknown_fee_token_fails() {
         let query = RelayQuery {
             fee_amount: U256::from(200_000_000),
-            fee_token: FeeToken::ERC20(address!("2222222222222222222222222222222222222222")),
+            fee_token: TokenKind::ERC20(address!("2222222222222222222222222222222222222222")),
             ..RelayQuery::default()
         };
         let mut request_trace = RequestTrace::new(&query);
@@ -227,7 +227,7 @@ mod erc20_fee {
 
         let query = RelayQuery {
             fee_amount: U256::from(200),
-            fee_token: FeeToken::ERC20(ERC20_ADDRESS),
+            fee_token: TokenKind::ERC20(ERC20_ADDRESS),
             ..RelayQuery::default()
         };
         let mut request_trace = RequestTrace::new(&query);
@@ -243,7 +243,7 @@ mod erc20_fee {
             token_pricing: vec![
                 erc20_pricing(),
                 TokenPricingConfig {
-                    token: FeeToken::Native,
+                    token: TokenKind::Native,
                     pricing: Pricing::Feed {
                         price_feed_coin: Coin::Btc,
                     },
@@ -256,7 +256,7 @@ mod erc20_fee {
 
         let query = RelayQuery {
             fee_amount: U256::from(100),
-            fee_token: FeeToken::ERC20(ERC20_ADDRESS),
+            fee_token: TokenKind::ERC20(ERC20_ADDRESS),
             ..RelayQuery::default()
         };
 

--- a/crates/shielder-relayer/tests/utils/mod.rs
+++ b/crates/shielder-relayer/tests/utils/mod.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{Address, Bytes, U256};
 use rand::Rng;
 use reqwest::Response;
 use serde::{Deserialize, Serialize};
-use shielder_relayer::{Coin, FeeToken, RelayQuery};
+use shielder_relayer::{Coin, TokenKind, RelayQuery};
 use shielder_setup::version::contract_version;
 use testcontainers::{
     core::IntoContainerPort, runners::AsyncRunner, ContainerAsync, ContainerRequest, Image,
@@ -73,7 +73,7 @@ impl TestContext {
                 nullifier_hash: U256::ZERO,
                 new_note: U256::ZERO,
                 proof: Bytes::new(),
-                fee_token: FeeToken::Native,
+                fee_token: TokenKind::Native,
                 fee_amount: U256::from_str("100_000_000_000_000_000").unwrap(),
                 mac_salt: U256::ZERO,
                 mac_commitment: U256::ZERO,

--- a/crates/shielder-relayer/tests/utils/mod.rs
+++ b/crates/shielder-relayer/tests/utils/mod.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{Address, Bytes, U256};
 use rand::Rng;
 use reqwest::Response;
 use serde::{Deserialize, Serialize};
-use shielder_relayer::{Coin, TokenKind, RelayQuery};
+use shielder_relayer::{Coin, RelayQuery, TokenKind};
 use shielder_setup::version::contract_version;
 use testcontainers::{
     core::IntoContainerPort, runners::AsyncRunner, ContainerAsync, ContainerRequest, Image,

--- a/crates/stress-testing/src/party.rs
+++ b/crates/stress-testing/src/party.rs
@@ -10,7 +10,7 @@ use shielder_circuits::{
 use shielder_contract::{
     alloy_primitives::U256, merkle_path::get_current_merkle_path, providers::create_simple_provider,
 };
-use shielder_relayer::{FeeToken, QuoteFeeResponse, RelayQuery};
+use shielder_relayer::{TokenKind, QuoteFeeResponse, RelayQuery};
 use shielder_setup::version::contract_version;
 
 use crate::{actor::Actor, config::Config, util::proving_keys, WITHDRAW_AMOUNT};
@@ -135,7 +135,7 @@ async fn prepare_relay_query(
         nullifier_hash: calldata.oldNullifierHash,
         new_note: calldata.newNote,
         proof: calldata.proof,
-        fee_token: FeeToken::Native,
+        fee_token: TokenKind::Native,
         fee_amount: calldata.relayerFee,
         mac_salt: calldata.macSalt,
         mac_commitment: calldata.macCommitment,

--- a/crates/stress-testing/src/party.rs
+++ b/crates/stress-testing/src/party.rs
@@ -10,7 +10,7 @@ use shielder_circuits::{
 use shielder_contract::{
     alloy_primitives::U256, merkle_path::get_current_merkle_path, providers::create_simple_provider,
 };
-use shielder_relayer::{TokenKind, QuoteFeeResponse, RelayQuery};
+use shielder_relayer::{QuoteFeeResponse, RelayQuery, TokenKind};
 use shielder_setup::version::contract_version;
 
 use crate::{actor::Actor, config::Config, util::proving_keys, WITHDRAW_AMOUNT};

--- a/tooling-e2e-tests/utils.sh
+++ b/tooling-e2e-tests/utils.sh
@@ -96,14 +96,17 @@ deploy_erc20_tokens() {
   TOKEN_CONFIG=$(cat <<EOF
   [
     {
+      "coin": "eth",
       "kind":"Native",
       "pricing":{"Fixed":{"price":"1"}}
     },
     {
+      "coin": "usdc",
       "kind":{"ERC20":"${TT1}"},
       "pricing":{"Fixed":{"price":"1"}}
     },
     {
+      "coin": "usdt",
       "kind":{"ERC20":"${TT2}"},
       "pricing":{"Fixed":{"price":"1"}}
     }

--- a/tooling-e2e-tests/utils.sh
+++ b/tooling-e2e-tests/utils.sh
@@ -93,24 +93,24 @@ deploy_erc20_tokens() {
   export TOKEN_CONTRACT_ADDRESSES
 
   # set pricing for relayer
-  TOKEN_PRICING=$(cat <<EOF
+  TOKEN_CONFIG=$(cat <<EOF
   [
     {
-      "token":"Native",
+      "kind":"Native",
       "pricing":{"Fixed":{"price":"1"}}
     },
     {
-      "token":{"ERC20":"${TT1}"},
+      "kind":{"ERC20":"${TT1}"},
       "pricing":{"Fixed":{"price":"1"}}
     },
     {
-      "token":{"ERC20":"${TT2}"},
+      "kind":{"ERC20":"${TT2}"},
       "pricing":{"Fixed":{"price":"1"}}
     }
   ]
 EOF
   )
-  export TOKEN_PRICING
+  export TOKEN_CONFIG
 
   log_progress "✅ Tokens deployed"
 }

--- a/tooling-e2e-tests/utils.sh
+++ b/tooling-e2e-tests/utils.sh
@@ -96,17 +96,17 @@ deploy_erc20_tokens() {
   TOKEN_CONFIG=$(cat <<EOF
   [
     {
-      "coin": "eth",
+      "coin": "Eth",
       "kind":"Native",
       "pricing":{"Fixed":{"price":"1"}}
     },
     {
-      "coin": "usdc",
+      "coin": "Usdc",
       "kind":{"ERC20":"${TT1}"},
       "pricing":{"Fixed":{"price":"1"}}
     },
     {
-      "coin": "usdt",
+      "coin": "Usdt",
       "kind":{"ERC20":"${TT2}"},
       "pricing":{"Fixed":{"price":"1"}}
     }


### PR DESCRIPTION
1. Rename `FeeToken` to `TokenKind` - this is an indicator, whether a coin is native or is deployed as an ERC20 contract (together with its address).
2. Rename and reorganize `TokenPricing*` to `TokenConfig` (structs, vars, envs). This holds full config for every token: coin id, kind, pricing.