### PR TITLE
Return account states list

### DIFF
--- a/ts/shielder-sdk/__tests/client/client.test.ts
+++ b/ts/shielder-sdk/__tests/client/client.test.ts
@@ -66,7 +66,8 @@ describe("ShielderClient", () => {
     } as unknown as Mocked<PublicClient>;
 
     mockAccountRegistry = {
-      getAccountState: vitest.fn()
+      getAccountState: vitest.fn(),
+      getAccountStatesList: vitest.fn()
     } as unknown as Mocked<AccountRegistry>;
 
     mockStateSynchronizer = {
@@ -213,6 +214,20 @@ describe("ShielderClient", () => {
         "syncing",
         "sync"
       );
+    });
+  });
+
+  describe("accountStatesList", () => {
+    it("should return account states list", async () => {
+      const mockAccountStates = [mockState];
+      mockAccountRegistry.getAccountStatesList.mockResolvedValue(
+        mockAccountStates
+      );
+
+      const accountStates = await client.accountStatesList();
+
+      expect(accountStates).toEqual(mockAccountStates);
+      expect(mockAccountRegistry.getAccountStatesList).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/ts/shielder-sdk/__tests/state/accountRegistry.test.ts
+++ b/ts/shielder-sdk/__tests/state/accountRegistry.test.ts
@@ -165,9 +165,6 @@ describe("AccountRegistry", () => {
         accountIndex,
         mockAccountObject
       );
-      expect(
-        storageManager.saveRawAccountAndIncrementNextAccountIndex
-      ).not.toHaveBeenCalled();
     });
 
     it("should create new account state when not found", async () => {
@@ -200,10 +197,10 @@ describe("AccountRegistry", () => {
         accountState,
         nextAccountIndex
       );
-      expect(storageManager.saveRawAccount).not.toHaveBeenCalled();
-      expect(
-        storageManager.saveRawAccountAndIncrementNextAccountIndex
-      ).toHaveBeenCalledWith(nextAccountIndex, mockAccountObject);
+      expect(storageManager.saveRawAccount).toHaveBeenCalledWith(
+        nextAccountIndex,
+        mockAccountObject
+      );
     });
   });
 
@@ -259,7 +256,6 @@ describe("AccountRegistry", () => {
       );
     });
     it("should return list of account states", async () => {
-      const accountIndex = 0;
       const accountObject = createMockAccountObject();
       const token = nativeToken();
       const accountState = createMockAccountState(token);
@@ -267,11 +263,8 @@ describe("AccountRegistry", () => {
       const token2 = erc20Token(testErc20Address);
       const accountState2 = createMockAccountState(token2);
 
-      await storageManager.saveRawAccount(accountIndex, accountObject);
-      await storageManager.saveRawAccountAndIncrementNextAccountIndex(
-        accountIndex + 1,
-        accountObject2
-      );
+      await storageManager.saveRawAccount(0, accountObject);
+      await storageManager.saveRawAccount(1, accountObject2);
 
       vi.mocked(accountStateSerde.toAccountState)
         .mockResolvedValueOnce(accountState)
@@ -282,12 +275,12 @@ describe("AccountRegistry", () => {
       expect(result).toEqual([accountState, accountState2]);
       expect(accountStateSerde.toAccountState).toHaveBeenCalledWith(
         accountObject,
-        accountIndex,
+        0,
         token
       );
       expect(accountStateSerde.toAccountState).toHaveBeenCalledWith(
         accountObject2,
-        accountIndex + 1,
+        1,
         token2
       );
     });

--- a/ts/shielder-sdk/package.json
+++ b/ts/shielder-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardinal-cryptography/shielder-sdk",
-  "version": "0.2.0-beta.2",
+  "version": "0.2.0-beta.3",
   "description": "A web package for interacting with Shielder, a part of zkOS privacy engine.",
   "license": "Apache-2.0",
   "keywords": [

--- a/ts/shielder-sdk/src/client/client.ts
+++ b/ts/shielder-sdk/src/client/client.ts
@@ -56,6 +56,14 @@ export class ShielderClient {
   }
 
   /**
+   * Get the list of all account states.
+   * @returns the list of all account states
+   */
+  async accountStatesList() {
+    return await this.accountRegistry.getAccountStatesList();
+  }
+
+  /**
    * Get the current account state for token.
    * @param {Token} token - token to get the account state for
    * @returns the current account state

--- a/ts/shielder-sdk/src/state/accountRegistry.ts
+++ b/ts/shielder-sdk/src/state/accountRegistry.ts
@@ -87,4 +87,18 @@ export class AccountRegistry {
 
     return null;
   }
+
+  async getAccountStatesList(): Promise<AccountStateMerkleIndexed[]> {
+    const accounts = await this.storageManager.getAllAccounts();
+
+    return Promise.all(
+      accounts.map(({ accountIndex, accountObject }) =>
+        this.accountStateSerde.toAccountState(
+          accountObject,
+          accountIndex,
+          getTokenByAddress(accountObject.tokenAddress as `0x${string}`)
+        )
+      )
+    );
+  }
 }

--- a/ts/shielder-sdk/src/state/accountRegistry.ts
+++ b/ts/shielder-sdk/src/state/accountRegistry.ts
@@ -59,7 +59,6 @@ export class AccountRegistry {
       accountState,
       accountIndex
     );
-    // Save
     await this.storageManager.saveRawAccount(accountIndex, accountObject);
   }
 

--- a/ts/shielder-sdk/src/state/accountRegistry.ts
+++ b/ts/shielder-sdk/src/state/accountRegistry.ts
@@ -51,31 +51,16 @@ export class AccountRegistry {
     const indexedAccount =
       await this.storageManager.findAccountByTokenAddress(tokenAddress);
 
-    if (indexedAccount !== null) {
-      // Existing account
-      const { accountIndex } = indexedAccount;
-      const accountObject = await this.accountStateSerde.toAccountObject(
-        accountState,
-        accountIndex
-      );
+    const { accountIndex } = indexedAccount ?? {
+      accountIndex: await this.storageManager.getNextAccountIndex()
+    };
 
-      // Save
-      await this.storageManager.saveRawAccount(accountIndex, accountObject);
-    } else {
-      // New account
-      const accountIndex = await this.storageManager.getNextAccountIndex();
-
-      const accountObject = await this.accountStateSerde.toAccountObject(
-        accountState,
-        accountIndex
-      );
-
-      // Save and increment index
-      await this.storageManager.saveRawAccountAndIncrementNextAccountIndex(
-        accountIndex,
-        accountObject
-      );
-    }
+    const accountObject = await this.accountStateSerde.toAccountObject(
+      accountState,
+      accountIndex
+    );
+    // Save
+    await this.storageManager.saveRawAccount(accountIndex, accountObject);
   }
 
   async getTokenByAccountIndex(accountIndex: number): Promise<Token | null> {

--- a/ts/shielder-sdk/src/storage/storageManager.ts
+++ b/ts/shielder-sdk/src/storage/storageManager.ts
@@ -20,6 +20,13 @@ export class StorageManager {
   async saveRawAccount(index: number, account: AccountObject): Promise<void> {
     const storageData = await this.storage.getStorage();
     storageData.accounts.set(index.toString(), { ...account });
+    if (index === storageData.nextAccountIndex) {
+      storageData.nextAccountIndex += 1;
+    } else if (index >= storageData.nextAccountIndex) {
+      throw new Error(
+        `Cannot save account at index ${index} when next account index is ${storageData.nextAccountIndex}`
+      );
+    }
     await this.storage.setStorage(storageData);
   }
 
@@ -29,19 +36,6 @@ export class StorageManager {
   async getNextAccountIndex(): Promise<number> {
     const storageData = await this.storage.getStorage();
     return storageData.nextAccountIndex;
-  }
-
-  /**
-   * Increments the next account index
-   */
-  async saveRawAccountAndIncrementNextAccountIndex(
-    index: number,
-    account: AccountObject
-  ): Promise<void> {
-    const storageData = await this.storage.getStorage();
-    storageData.accounts.set(index.toString(), { ...account });
-    storageData.nextAccountIndex += 1;
-    await this.storage.setStorage(storageData);
   }
 
   /**

--- a/ts/shielder-sdk/src/storage/storageManager.ts
+++ b/ts/shielder-sdk/src/storage/storageManager.ts
@@ -64,4 +64,19 @@ export class StorageManager {
 
     return null;
   }
+
+  /**
+   * Gets all accounts
+   */
+  async getAllAccounts(): Promise<
+    { accountIndex: number; accountObject: AccountObject }[]
+  > {
+    const storageData = await this.storage.getStorage();
+    return Array.from(storageData.accounts.entries()).map(
+      ([index, account]) => ({
+        accountIndex: parseInt(index),
+        accountObject: { ...account }
+      })
+    );
+  }
 }

--- a/ts/shielder-sdk/src/storage/storageManager.ts
+++ b/ts/shielder-sdk/src/storage/storageManager.ts
@@ -19,14 +19,14 @@ export class StorageManager {
    */
   async saveRawAccount(index: number, account: AccountObject): Promise<void> {
     const storageData = await this.storage.getStorage();
-    storageData.accounts.set(index.toString(), { ...account });
     if (index === storageData.nextAccountIndex) {
       storageData.nextAccountIndex += 1;
-    } else if (index >= storageData.nextAccountIndex) {
+    } else if (index > storageData.nextAccountIndex) {
       throw new Error(
         `Cannot save account at index ${index} when next account index is ${storageData.nextAccountIndex}`
       );
     }
+    storageData.accounts.set(index.toString(), { ...account });
     await this.storage.setStorage(storageData);
   }
 


### PR DESCRIPTION
- add an endpoint which returns the list of all accounts state from storage, so the SDK user can easily retrieve them.
- remove `saveRawAccountAndIncrementNextAccountIndex` function and embed `accountIndex` increment in `saveRawAccount` function