### PR TITLE
Remove MAC salt from account

### DIFF
--- a/crates/integration-tests/src/shielder/calls/deposit.rs
+++ b/crates/integration-tests/src/shielder/calls/deposit.rs
@@ -2,14 +2,14 @@ use std::str::FromStr;
 
 use alloy_primitives::{Address, TxHash, U256};
 use shielder_account::{
-    call_data::{DepositCall, DepositCallType, MerkleProof, Token},
+    call_data::{DepositCall, DepositCallType, DepositExtra, Token},
     ShielderAccount,
 };
 use shielder_contract::ShielderContract::{depositERC20Call, depositNativeCall};
 
 use crate::{
     deploy::ACTOR_ADDRESS,
-    shielder::{deploy::Deployment, invoke_shielder_call, merkle::get_merkle_args, CallResult},
+    shielder::{deploy::Deployment, invoke_shielder_call, merkle::get_merkle_path, CallResult},
     TestToken,
 };
 pub fn prepare_call(
@@ -23,7 +23,7 @@ pub fn prepare_call(
         .expect("No leaf index");
 
     let (params, pk) = deployment.deposit_proving_params.clone();
-    let (merkle_root, merkle_path) = get_merkle_args(
+    let merkle_path = get_merkle_path(
         deployment.contract_suite.shielder,
         note_index,
         &mut deployment.evm,
@@ -33,9 +33,9 @@ pub fn prepare_call(
         &pk,
         token.token(deployment),
         amount,
-        &MerkleProof {
-            root: merkle_root,
-            path: merkle_path,
+        &DepositExtra {
+            merkle_path,
+            mac_salt: U256::ZERO,
         },
     );
     (calldata, note_index)

--- a/crates/integration-tests/src/shielder/calls/withdraw_native.rs
+++ b/crates/integration-tests/src/shielder/calls/withdraw_native.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use alloy_primitives::{Address, TxHash, U256};
 use shielder_account::{
-    call_data::{MerkleProof, Token, WithdrawCallType, WithdrawExtra},
+    call_data::{Token, WithdrawCallType, WithdrawExtra},
     ShielderAccount,
 };
 use shielder_contract::ShielderContract::withdrawNativeCall;
@@ -11,7 +11,7 @@ use shielder_setup::version::ContractVersion;
 use crate::shielder::{
     deploy::{Deployment, RECIPIENT_ADDRESS, RELAYER_ADDRESS},
     invoke_shielder_call,
-    merkle::get_merkle_args,
+    merkle::get_merkle_path,
     CallResult,
 };
 
@@ -41,7 +41,7 @@ pub fn prepare_call(
         .expect("No leaf index");
 
     let (params, pk) = deployment.withdraw_proving_params.clone();
-    let (merkle_root, merkle_path) = get_merkle_args(
+    let merkle_path = get_merkle_path(
         deployment.contract_suite.shielder,
         note_index,
         &mut deployment.evm,
@@ -53,10 +53,7 @@ pub fn prepare_call(
         Token::Native,
         U256::from(args.amount),
         &WithdrawExtra {
-            merkle_proof: MerkleProof {
-                root: merkle_root,
-                path: merkle_path,
-            },
+            merkle_path,
             to: args.withdraw_address,
             relayer_address: args.relayer_address,
             relayer_fee: args.relayer_fee,
@@ -66,6 +63,7 @@ pub fn prepare_call(
                 patch_version: 0,
             },
             chain_id: U256::from(1),
+            mac_salt: U256::ZERO,
         },
     );
 

--- a/crates/integration-tests/src/shielder/merkle.rs
+++ b/crates/integration-tests/src/shielder/merkle.rs
@@ -2,13 +2,13 @@ use alloy_primitives::{Address, U256};
 use alloy_sol_types::{SolCall, SolValue};
 use evm_utils::EvmRunner;
 use shielder_circuits::consts::merkle_constants::{ARITY, NOTE_TREE_HEIGHT};
-use shielder_contract::ShielderContract::getMerklePathCall;
+use shielder_contract::{merkle_path::reorganize_merkle_path, ShielderContract::getMerklePathCall};
 
-pub fn get_merkle_args(
+pub fn get_merkle_path(
     shielder_address: Address,
     note_index: U256,
     evm: &mut EvmRunner,
-) -> (U256, [[U256; ARITY]; NOTE_TREE_HEIGHT]) {
+) -> [[U256; ARITY]; NOTE_TREE_HEIGHT] {
     let calldata = getMerklePathCall { id: note_index }.abi_encode();
     let result = evm
         .call(shielder_address, calldata, None, None)
@@ -16,23 +16,8 @@ pub fn get_merkle_args(
         .output;
     let decoded = <Vec<U256>>::abi_decode(&result, true).expect("Decoding failed");
     reorganize_merkle_path(decoded)
-}
-
-fn reorganize_merkle_path(merkle_path: Vec<U256>) -> (U256, [[U256; ARITY]; NOTE_TREE_HEIGHT]) {
-    assert_eq!(merkle_path.len(), ARITY * NOTE_TREE_HEIGHT + 1);
-
-    let root = *merkle_path.last().expect("Empty merkle path");
-
-    let mut result = [[U256::ZERO; ARITY]; NOTE_TREE_HEIGHT];
-    for (i, element) in merkle_path
-        .into_iter()
-        .enumerate()
-        .take(ARITY * NOTE_TREE_HEIGHT)
-    {
-        result[i / ARITY][i % ARITY] = element;
-    }
-
-    (root, result)
+        .expect("Reorganizing failed")
+        .1
 }
 
 #[cfg(test)]

--- a/crates/shielder-account/src/call_data.rs
+++ b/crates/shielder-account/src/call_data.rs
@@ -261,14 +261,14 @@ impl TryFrom<DepositCall> for depositERC20Call {
     }
 }
 
-pub struct MerkleProof {
-    pub root: U256,
-    pub path: [[U256; ARITY]; NOTE_TREE_HEIGHT],
+pub struct DepositExtra {
+    pub merkle_path: [[U256; ARITY]; NOTE_TREE_HEIGHT],
+    pub mac_salt: U256,
 }
 
 pub enum DepositCallType {}
 impl CallType for DepositCallType {
-    type Extra = MerkleProof;
+    type Extra = DepositExtra;
     type ProverKnowledge = DepositProverKnowledge<Fr>;
 
     type Calldata = DepositCall;
@@ -277,7 +277,7 @@ impl CallType for DepositCallType {
         account: &ShielderAccount,
         token: Token,
         amount: U256,
-        merkle: &Self::Extra,
+        extra: &Self::Extra,
     ) -> Self::ProverKnowledge {
         let ActionSecrets {
             nullifier_old,
@@ -293,11 +293,11 @@ impl CallType for DepositCallType {
             trapdoor_old: u256_to_field(trapdoor_old),
             account_old_balance: u256_to_field(account.shielded_amount),
             token_address: address_to_field(token.address()),
-            path: map_path_to_field(merkle.path),
+            path: map_path_to_field(extra.merkle_path),
             deposit_value: u256_to_field(amount),
             nullifier_new: u256_to_field(nullifier_new),
             trapdoor_new: u256_to_field(trapdoor_new),
-            mac_salt: u256_to_field(account.mac_salt),
+            mac_salt: u256_to_field(extra.mac_salt),
         }
     }
 
@@ -322,12 +322,13 @@ impl CallType for DepositCallType {
 }
 
 pub struct WithdrawExtra {
-    pub merkle_proof: MerkleProof,
+    pub merkle_path: [[U256; ARITY]; NOTE_TREE_HEIGHT],
     pub to: Address,
     pub relayer_address: Address,
     pub relayer_fee: U256,
     pub contract_version: ContractVersion,
     pub chain_id: U256,
+    pub mac_salt: U256,
 }
 
 pub enum WithdrawCallType {}
@@ -365,12 +366,12 @@ impl CallType for WithdrawCallType {
             trapdoor_old: u256_to_field(trapdoor_old),
             account_old_balance: u256_to_field(account.shielded_amount),
             token_address: address_to_field(token.address()),
-            path: map_path_to_field(extra.merkle_proof.path),
+            path: map_path_to_field(extra.merkle_path),
             withdrawal_value: u256_to_field(amount),
             nullifier_new: u256_to_field(nullifier_new),
             trapdoor_new: u256_to_field(trapdoor_new),
             commitment: u256_to_field(commitment),
-            mac_salt: u256_to_field(account.mac_salt),
+            mac_salt: u256_to_field(extra.mac_salt),
         }
     }
 

--- a/crates/shielder-account/src/lib.rs
+++ b/crates/shielder-account/src/lib.rs
@@ -22,8 +22,6 @@ pub struct ShielderAccount {
     /// WARNING: You SHOULD NOT use `Self::Default` in production, as this will set the seed to
     /// zero, which is insecure and might get in conflict with other accounts (similarly set up).
     pub id: U256,
-    /// Salt used to generate the MAC for the account.
-    pub mac_salt: U256,
     /// The nonce used to generate nullifiers and trapdoors. It is incremented after each action.
     pub nonce: u32,
     /// The total current amount of tokens shielded by the account.
@@ -36,7 +34,6 @@ impl Display for ShielderAccount {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ShielderAccount")
             .field("id", &self.id)
-            .field("MAC salt", &self.mac_salt)
             .field("nonce", &self.nonce)
             .field("shielded_amount", &self.shielded_amount)
             .field("current_leaf_index", &self.current_leaf_index())

--- a/crates/shielder-cli/src/shielder_ops/mod.rs
+++ b/crates/shielder-cli/src/shielder_ops/mod.rs
@@ -1,3 +1,7 @@
+use alloy_primitives::{
+    private::rand::{rngs::OsRng, Rng},
+    U256,
+};
 pub use deposit::deposit;
 pub use new_account::new_account;
 pub use withdraw::withdraw;
@@ -6,3 +10,8 @@ mod deposit;
 mod new_account;
 mod pk;
 mod withdraw;
+
+fn get_mac_salt() -> U256 {
+    let mut rng = OsRng;
+    U256::from_limbs([rng.gen(), rng.gen(), rng.gen(), rng.gen()])
+}

--- a/crates/shielder-cli/src/shielder_ops/new_account.rs
+++ b/crates/shielder-cli/src/shielder_ops/new_account.rs
@@ -17,7 +17,10 @@ use tracing::{debug, info};
 
 use crate::{
     app_state::AppState,
-    shielder_ops::pk::{get_proving_equipment, CircuitType},
+    shielder_ops::{
+        get_mac_salt,
+        pk::{get_proving_equipment, CircuitType},
+    },
 };
 
 pub async fn new_account(app_state: &mut AppState, amount: u128) -> Result<()> {
@@ -68,9 +71,4 @@ pub async fn new_account(app_state: &mut AppState, amount: u128) -> Result<()> {
 fn get_encryption_salt() -> [bool; FIELD_BITS] {
     let mut rng = OsRng;
     core::array::from_fn(|_| rng.gen_bool(0.5))
-}
-
-fn get_mac_salt() -> U256 {
-    let mut rng = OsRng;
-    U256::from_limbs([rng.gen(), rng.gen(), rng.gen(), rng.gen()])
 }

--- a/crates/shielder-cli/src/shielder_ops/withdraw.rs
+++ b/crates/shielder-cli/src/shielder_ops/withdraw.rs
@@ -5,7 +5,7 @@ use alloy_provider::Provider;
 use anyhow::{anyhow, bail, Result};
 use serde::Serialize;
 use shielder_account::{
-    call_data::{MerkleProof, Token, WithdrawCallType, WithdrawExtra},
+    call_data::{Token, WithdrawCallType, WithdrawExtra},
     ShielderAction,
 };
 use shielder_contract::{
@@ -18,7 +18,10 @@ use tracing::{debug, info};
 
 use crate::{
     app_state::{AppState, RelayerRpcUrl},
-    shielder_ops::pk::{get_proving_equipment, CircuitType},
+    shielder_ops::{
+        get_mac_salt,
+        pk::{get_proving_equipment, CircuitType},
+    },
 };
 
 pub async fn withdraw(app_state: &mut AppState, amount: u128, to: Address) -> Result<()> {
@@ -133,15 +136,13 @@ async fn prepare_relayer_query(
         Token::Native,
         amount,
         &WithdrawExtra {
-            merkle_proof: MerkleProof {
-                root: merkle_root,
-                path: merkle_path,
-            },
+            merkle_path,
             to,
             relayer_address: get_relayer_address(&app_state.relayer_rpc_url).await?,
             relayer_fee,
             contract_version: contract_version(),
             chain_id: U256::from(chain_id),
+            mac_salt: get_mac_salt(),
         },
     );
 

--- a/crates/shielder-contract/src/merkle_path.rs
+++ b/crates/shielder-contract/src/merkle_path.rs
@@ -14,7 +14,7 @@ pub async fn get_current_merkle_path(
 }
 
 /// Reorganize a flattened merkle path into a 2D array and a root element.
-fn reorganize_merkle_path(
+pub fn reorganize_merkle_path(
     merkle_path: Vec<U256>,
 ) -> ContractResult<(U256, [[U256; ARITY]; TREE_HEIGHT])> {
     if merkle_path.len() != ARITY * TREE_HEIGHT + 1 {
@@ -23,14 +23,14 @@ fn reorganize_merkle_path(
 
     let root = *merkle_path.last().expect("Empty merkle path");
 
-    let mut result = [[U256::ZERO; ARITY]; TREE_HEIGHT];
+    let mut path = [[U256::ZERO; ARITY]; TREE_HEIGHT];
     for (i, element) in merkle_path
         .into_iter()
         .enumerate()
         .take(ARITY * TREE_HEIGHT)
     {
-        result[i / ARITY][i % ARITY] = element;
+        path[i / ARITY][i % ARITY] = element;
     }
 
-    Ok((root, result))
+    Ok((root, path))
 }

--- a/crates/stress-testing/src/party.rs
+++ b/crates/stress-testing/src/party.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use alloy_provider::Provider;
 use anyhow::Result;
-use shielder_account::call_data::{MerkleProof, Token, WithdrawCallType, WithdrawExtra};
+use shielder_account::call_data::{Token, WithdrawCallType, WithdrawExtra};
 use shielder_circuits::{
     circuits::{Params, ProvingKey},
     withdraw::WithdrawCircuit,
@@ -114,15 +114,13 @@ async fn prepare_relay_query(
         Token::Native,
         U256::from(WITHDRAW_AMOUNT),
         &WithdrawExtra {
-            merkle_proof: MerkleProof {
-                root: merkle_root,
-                path: merkle_path,
-            },
+            merkle_path,
             to,
             relayer_address: config.relayer_address,
             relayer_fee,
             contract_version: contract_version(),
             chain_id: U256::from(chain_id),
+            mac_salt: U256::ZERO,
         },
     );
 


### PR DESCRIPTION
1. Remove MAC salt from the shielder account
2. Simplify calldata extras structs
3. Reuse Merkle path reorganization code