### PR TITLE
Relayer query extension

### DIFF
--- a/crates/shielder-relayer/src/lib.rs
+++ b/crates/shielder-relayer/src/lib.rs
@@ -1,8 +1,3 @@
-use axum::{
-    http::StatusCode,
-    response::{IntoResponse, Response},
-    Json,
-};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use shielder_contract::alloy_primitives::{Address, Bytes, FixedBytes, TxHash, U256};
@@ -14,19 +9,12 @@ use shielder_account::Token;
 
 mod token;
 pub use token::*;
+pub mod server;
 
 #[derive(Clone, Debug, Deserialize, Serialize, ToSchema)]
 #[serde(transparent)]
 pub struct SimpleServiceResponse {
     pub message: String,
-}
-
-impl SimpleServiceResponse {
-    pub fn from(message: &str) -> Json<Self> {
-        Json(Self {
-            message: message.to_string(),
-        })
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, ToSchema)]
@@ -118,11 +106,6 @@ pub struct RelayQuery {
     pub mac_commitment: U256,
     #[schema(value_type = String)]
     pub pocket_money: U256,
-}
-
-pub fn server_error(msg: &str) -> Response {
-    let code = StatusCode::INTERNAL_SERVER_ERROR;
-    (code, SimpleServiceResponse::from(msg)).into_response()
 }
 
 pub const RELATIVE_PRICE_DIGITS: u32 = 20;

--- a/crates/shielder-relayer/src/lib.rs
+++ b/crates/shielder-relayer/src/lib.rs
@@ -81,7 +81,7 @@ pub struct QuoteFeeQuery {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, ToSchema)]
-pub struct RelayQuery {
+pub struct RelayCalldata {
     #[schema(value_type = Object)]
     pub expected_contract_version: FixedBytes<3>,
     #[schema(value_type = String)]
@@ -106,6 +106,20 @@ pub struct RelayQuery {
     pub mac_commitment: U256,
     #[schema(value_type = String)]
     pub pocket_money: U256,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, ToSchema)]
+pub struct RelayQuote {
+    #[schema(value_type = String)]
+    pub gas_price: U256,
+    pub native_token_price: Decimal,
+    pub token_price_ratio: Decimal,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, ToSchema)]
+pub struct RelayQuery {
+    pub calldata: RelayCalldata,
+    pub quote: RelayQuote,
 }
 
 pub const RELATIVE_PRICE_DIGITS: u32 = 20;

--- a/crates/shielder-relayer/src/lib.rs
+++ b/crates/shielder-relayer/src/lib.rs
@@ -35,12 +35,6 @@ pub struct RelayResponse {
     pub tx_hash: TxHash,
 }
 
-impl RelayResponse {
-    pub fn from(tx_hash: TxHash) -> Json<Self> {
-        Json(Self { tx_hash })
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize, ToSchema)]
 pub struct QuoteFeeResponse {
     // 8< ----------------------------------------------------- >8  TO BE REMOVED SOON

--- a/crates/shielder-relayer/src/quote.rs
+++ b/crates/shielder-relayer/src/quote.rs
@@ -1,10 +1,12 @@
 use alloy_provider::Provider;
-use axum::{extract::State, http::status::StatusCode, response::IntoResponse, Json};
+use axum::{extract::State, response::IntoResponse, Json};
 use rust_decimal::Decimal;
 use shielder_account::Token;
 use shielder_contract::{alloy_primitives::U256, providers::create_simple_provider};
 use shielder_relayer::{
-    scale_u256, server_error, QuoteFeeQuery, QuoteFeeResponse, SimpleServiceResponse, TokenKind,
+    scale_u256,
+    server::{server_error, success_response},
+    QuoteFeeQuery, QuoteFeeResponse, SimpleServiceResponse, TokenKind,
 };
 use time::OffsetDateTime;
 use tracing::error;
@@ -26,7 +28,7 @@ pub async fn quote_fees(
     Json(query): Json<QuoteFeeQuery>,
 ) -> impl IntoResponse {
     match _quote_fees(app_state, query).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Ok(response) => success_response(response),
         Err(err) => {
             error!(err);
             server_error(&err)

--- a/crates/shielder-relayer/src/relay/request_trace.rs
+++ b/crates/shielder-relayer/src/relay/request_trace.rs
@@ -27,7 +27,7 @@ pub struct RequestTrace {
 impl RequestTrace {
     pub fn new(relay_query: &RelayQuery) -> Self {
         Self {
-            created_note: relay_query.new_note,
+            created_note: relay_query.calldata.new_note,
             measurements: Vec::new(),
             last_timestamp: Instant::now(),
             current_state: "created",

--- a/crates/shielder-relayer/src/server.rs
+++ b/crates/shielder-relayer/src/server.rs
@@ -1,0 +1,36 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::Serialize;
+
+use crate::SimpleServiceResponse;
+
+pub fn success(msg: &str) -> Response {
+    (StatusCode::OK, jsonize_str(msg)).into_response()
+}
+
+pub fn success_response<R: Serialize>(response: R) -> Response {
+    (StatusCode::OK, Json(response)).into_response()
+}
+
+pub fn server_error(msg: &str) -> Response {
+    let code = StatusCode::INTERNAL_SERVER_ERROR;
+    (code, jsonize_str(msg)).into_response()
+}
+
+pub fn bad_request(msg: &str) -> Response {
+    (StatusCode::BAD_REQUEST, jsonize_str(msg)).into_response()
+}
+
+pub fn temporary_failure(msg: &str) -> Response {
+    let code = StatusCode::SERVICE_UNAVAILABLE;
+    (code, jsonize_str(msg)).into_response()
+}
+
+fn jsonize_str(msg: &str) -> Json<SimpleServiceResponse> {
+    Json(SimpleServiceResponse {
+        message: msg.into(),
+    })
+}

--- a/crates/shielder-relayer/tests/utils/mod.rs
+++ b/crates/shielder-relayer/tests/utils/mod.rs
@@ -8,7 +8,9 @@ use reqwest::Response;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use shielder_account::Token;
-use shielder_relayer::{PriceProvider, RelayQuery, TokenInfo, TokenKind};
+use shielder_relayer::{
+    PriceProvider, RelayCalldata, RelayQuery, RelayQuote, TokenInfo, TokenKind,
+};
 use shielder_setup::version::contract_version;
 use testcontainers::{
     core::IntoContainerPort, runners::AsyncRunner, ContainerAsync, ContainerRequest, Image,
@@ -70,18 +72,25 @@ impl TestContext {
         reqwest::Client::new()
             .post(format!("{BASE_URL}:{}/relay", self.relayer_port))
             .json(&RelayQuery {
-                expected_contract_version: contract_version().to_bytes(),
-                amount: U256::from(1),
-                withdraw_address: Address::from_str(FEE_DESTINATION).unwrap(),
-                merkle_root: U256::ZERO,
-                nullifier_hash: U256::ZERO,
-                new_note: U256::ZERO,
-                proof: Bytes::new(),
-                fee_token: Token::Native,
-                fee_amount: U256::from_str("100_000_000_000_000_000").unwrap(),
-                mac_salt: U256::ZERO,
-                mac_commitment: U256::ZERO,
-                pocket_money: U256::ZERO,
+                calldata: RelayCalldata {
+                    expected_contract_version: contract_version().to_bytes(),
+                    amount: U256::from(1),
+                    withdraw_address: Address::from_str(FEE_DESTINATION).unwrap(),
+                    merkle_root: U256::ZERO,
+                    nullifier_hash: U256::ZERO,
+                    new_note: U256::ZERO,
+                    proof: Bytes::new(),
+                    fee_token: Token::Native,
+                    fee_amount: U256::from_str("100_000_000_000_000_000").unwrap(),
+                    mac_salt: U256::ZERO,
+                    mac_commitment: U256::ZERO,
+                    pocket_money: U256::ZERO,
+                },
+                quote: RelayQuote {
+                    gas_price: Default::default(),
+                    native_token_price: Default::default(),
+                    token_price_ratio: Default::default(),
+                },
             })
             .send()
             .await

--- a/crates/stress-testing/src/party.rs
+++ b/crates/stress-testing/src/party.rs
@@ -14,7 +14,7 @@ use shielder_contract::{
     alloy_primitives::U256, merkle_path::get_current_merkle_path,
     providers::create_simple_provider, ShielderContract::withdrawNativeCall,
 };
-use shielder_relayer::{QuoteFeeResponse, RelayQuery};
+use shielder_relayer::{QuoteFeeResponse, RelayCalldata, RelayQuery};
 use shielder_setup::version::contract_version;
 
 use crate::{actor::Actor, config::Config, util::proving_keys, WITHDRAW_AMOUNT};
@@ -133,18 +133,21 @@ async fn prepare_relay_query(
         .unwrap();
 
     let query = RelayQuery {
-        expected_contract_version: contract_version().to_bytes(),
-        amount: U256::from(WITHDRAW_AMOUNT),
-        withdraw_address: to,
-        merkle_root,
-        nullifier_hash: calldata.oldNullifierHash,
-        new_note: calldata.newNote,
-        proof: calldata.proof,
-        fee_token: Token::Native,
-        fee_amount: calldata.relayerFee,
-        mac_salt: calldata.macSalt,
-        mac_commitment: calldata.macCommitment,
-        pocket_money: U256::ZERO,
+        calldata: RelayCalldata {
+            expected_contract_version: contract_version().to_bytes(),
+            amount: U256::from(WITHDRAW_AMOUNT),
+            withdraw_address: to,
+            merkle_root,
+            nullifier_hash: calldata.oldNullifierHash,
+            new_note: calldata.newNote,
+            proof: calldata.proof,
+            fee_token: Token::Native,
+            fee_amount: calldata.relayerFee,
+            mac_salt: calldata.macSalt,
+            mac_commitment: calldata.macCommitment,
+            pocket_money: U256::ZERO,
+        },
+        quote: Default::default(),
     };
     println!("  ✅ Prepared relay query for actor {}", actor.id);
     Ok(query)

--- a/ts/shielder-sdk-tests/web/fixtures/shielderClient.ts
+++ b/ts/shielder-sdk-tests/web/fixtures/shielderClient.ts
@@ -103,12 +103,12 @@ export const setupShielderClient = async (
       return {
         tx: await shielderClient.withdraw(
           token,
-          amount + fees.totalFee,
-          fees.totalFee,
+          amount + fees.total_fee,
+          fees,
           to,
           pocketMoney
         ),
-        totalFee: fees.totalFee
+        totalFee: fees.total_fee
       };
     },
     withdrawManual: async (token, amount, to) => {

--- a/ts/shielder-sdk/__tests/actions/withdraw.test.ts
+++ b/ts/shielder-sdk/__tests/actions/withdraw.test.ts
@@ -11,7 +11,7 @@ import { MockedCryptoClient, hashedNote } from "../helpers";
 
 import { WithdrawAction } from "../../src/actions/withdraw";
 import { IContract } from "../../src/chain/contract";
-import { IRelayer, WithdrawResponse } from "../../src/chain/relayer";
+import { IRelayer, quotedFeesFromTotalFee, WithdrawResponse } from "../../src/chain/relayer";
 import { nativeToken } from "../../src/utils";
 import { OutdatedSdkError } from "../../src/errors";
 import { AccountStateMerkleIndexed } from "../../src/state/types";
@@ -143,7 +143,7 @@ describe("WithdrawAction", () => {
         state,
         amount,
         mockRelayerAddress,
-        totalFee,
+        quotedFeesFromTotalFee(totalFee),
         address,
         expectedVersion,
         pocketMoney
@@ -173,7 +173,7 @@ describe("WithdrawAction", () => {
           state,
           amount,
           mockRelayerAddress,
-          totalFee,
+          quotedFeesFromTotalFee(totalFee),
           mockAddress,
           expectedVersion,
           pocketMoney
@@ -191,7 +191,7 @@ describe("WithdrawAction", () => {
           state,
           amount,
           mockRelayerAddress,
-          totalFee,
+          quotedFeesFromTotalFee(totalFee),
           mockAddress,
           expectedVersion,
           pocketMoney
@@ -209,7 +209,7 @@ describe("WithdrawAction", () => {
           state,
           amount,
           mockRelayerAddress,
-          totalFee,
+          quotedFeesFromTotalFee(totalFee),
           mockAddress,
           expectedVersion,
           pocketMoney
@@ -232,7 +232,7 @@ describe("WithdrawAction", () => {
           state,
           amount,
           mockRelayerAddress,
-          totalFee,
+          quotedFeesFromTotalFee(totalFee),
           mockAddress,
           expectedVersion,
           pocketMoney
@@ -260,7 +260,7 @@ describe("WithdrawAction", () => {
           state,
           amount,
           mockRelayerAddress,
-          totalFee,
+          quotedFeesFromTotalFee(totalFee),
           mockAddress,
           expectedVersion,
           pocketMoney
@@ -279,7 +279,7 @@ describe("WithdrawAction", () => {
         state,
         amount,
         mockRelayerAddress,
-        totalFee,
+        quotedFeesFromTotalFee(totalFee),
         mockAddress,
         expectedVersion,
         pocketMoney
@@ -290,7 +290,7 @@ describe("WithdrawAction", () => {
       expect(relayer.withdraw).toHaveBeenCalledWith(
         expectedVersion,
         nativeToken(),
-        calldata.totalFee,
+        calldata.quotedFees.total_fee,
         scalarToBigint(calldata.calldata.pubInputs.hNullifierOld),
         scalarToBigint(calldata.calldata.pubInputs.hNoteNew),
         scalarToBigint(calldata.calldata.pubInputs.merkleRoot),
@@ -299,7 +299,8 @@ describe("WithdrawAction", () => {
         mockAddress,
         scalarToBigint(calldata.calldata.pubInputs.macSalt),
         scalarToBigint(calldata.calldata.pubInputs.macCommitment),
-        calldata.pocketMoney
+        calldata.pocketMoney,
+        quotedFeesFromTotalFee(totalFee)
       );
 
       expect(txHash).toBe("0xtxHash");
@@ -314,7 +315,7 @@ describe("WithdrawAction", () => {
         state,
         amount,
         mockRelayerAddress,
-        totalFee,
+        quotedFeesFromTotalFee(totalFee),
         mockAddress,
         expectedVersion,
         pocketMoney
@@ -354,7 +355,7 @@ describe("WithdrawAction", () => {
         state,
         amount,
         mockRelayerAddress,
-        totalFee,
+        quotedFeesFromTotalFee(totalFee),
         mockAddress,
         expectedVersion,
         pocketMoney

--- a/ts/shielder-sdk/__tests/client/actions.test.ts
+++ b/ts/shielder-sdk/__tests/client/actions.test.ts
@@ -9,7 +9,7 @@ import {
 } from "../../src/client/types";
 import { AccountRegistry } from "../../src/state/accountRegistry";
 import { StateSynchronizer } from "../../src/state/sync/synchronizer";
-import { IRelayer } from "../../src/chain/relayer";
+import { IRelayer, quotedFeesFromTotalFee } from "../../src/chain/relayer";
 import { NewAccountAction } from "../../src/actions/newAccount";
 import { DepositAction } from "../../src/actions/deposit";
 import { WithdrawAction } from "../../src/actions/withdraw";
@@ -115,7 +115,7 @@ describe("ShielderActions", () => {
     provingTimeMillis: 100,
     amount: mockAmount,
     withdrawalAddress: mockAddress,
-    totalFee,
+    quotedFees: quotedFeesFromTotalFee(totalFee),
     token: mockToken,
     pocketMoney: mockPocketMoney
   });
@@ -286,7 +286,19 @@ describe("ShielderActions", () => {
       const mockFees = {
         base_fee: 1000n,
         relay_fee: 500n,
-        total_fee: 1500n
+        total_fee: 1500n,
+        total_cost_native: 1500n,
+        total_cost_fee_token: 0n,
+        gas_price: 0n,
+        gas_cost_native: 0n,
+        gas_cost_fee_token: 0n,
+        commission_native: 0n,
+        commission_fee_token: 0n,
+        native_token_price: "1",
+        native_token_unit_price: "1",
+        fee_token_price: "1",
+        fee_token_unit_price: "1",
+        token_price_ratio: "1"
       };
 
       mockRelayer.quoteFees.mockResolvedValue(mockFees);
@@ -484,7 +496,7 @@ describe("ShielderActions", () => {
 
   describe("withdraw", () => {
     const withdrawMethod = () =>
-      actions.withdraw(mockToken, mockAmount, mockTotalFee, mockAddress, mockPocketMoney);
+      actions.withdraw(mockToken, mockAmount, quotedFeesFromTotalFee(mockTotalFee), mockAddress, mockPocketMoney);
 
     it("should throw error when account not found", async () => {
       mockAccountRegistry.getAccountState.mockResolvedValue(null);
@@ -514,7 +526,7 @@ describe("ShielderActions", () => {
         mockAccountState,
         mockAmount,
         mockRelayerAddress,
-        mockTotalFee,
+        quotedFeesFromTotalFee(mockTotalFee),
         mockAddress,
         contractVersion,
         mockPocketMoney
@@ -576,8 +588,7 @@ describe("ShielderActions", () => {
         mockAmount,
         mockAddress,
         mockSendTransaction,
-        mockFrom,
-        mockPocketMoney
+        mockFrom
       );
 
     it("should throw error when account not found", async () => {
@@ -606,7 +617,7 @@ describe("ShielderActions", () => {
         mockAccountState,
         mockAmount,
         mockFrom,
-        0n, // totalFee is 0 for manual withdrawals
+        quotedFeesFromTotalFee(0n),
         mockAddress,
         contractVersion,
         mockPocketMoney

--- a/ts/shielder-sdk/__tests/client/actions.test.ts
+++ b/ts/shielder-sdk/__tests/client/actions.test.ts
@@ -305,11 +305,7 @@ describe("ShielderActions", () => {
 
       const fees = await actions.getWithdrawFees();
 
-      expect(fees).toEqual({
-        baseFee: mockFees.base_fee,
-        relayFee: mockFees.relay_fee,
-        totalFee: mockFees.total_fee
-      });
+      expect(fees).toEqual(mockFees);
       expect(mockRelayer.quoteFees).toHaveBeenCalledTimes(1);
     });
   });
@@ -496,7 +492,13 @@ describe("ShielderActions", () => {
 
   describe("withdraw", () => {
     const withdrawMethod = () =>
-      actions.withdraw(mockToken, mockAmount, quotedFeesFromTotalFee(mockTotalFee), mockAddress, mockPocketMoney);
+      actions.withdraw(
+        mockToken,
+        mockAmount,
+        quotedFeesFromTotalFee(mockTotalFee),
+        mockAddress,
+        mockPocketMoney
+      );
 
     it("should throw error when account not found", async () => {
       mockAccountRegistry.getAccountState.mockResolvedValue(null);

--- a/ts/shielder-sdk/src/actions/withdraw.ts
+++ b/ts/shielder-sdk/src/actions/withdraw.ts
@@ -8,7 +8,7 @@ import {
   WithdrawPubInputs
 } from "@cardinal-cryptography/shielder-sdk-crypto";
 import { Address, encodePacked, hexToBigInt, keccak256 } from "viem";
-import { IRelayer, QuoteFeesResponse } from "@/chain/relayer";
+import { IRelayer, QuotedFees } from "@/chain/relayer";
 import { NoteAction } from "@/actions/utils";
 import { Token } from "@/types";
 import { getAddressByToken } from "@/utils";
@@ -25,7 +25,7 @@ export interface WithdrawCalldata {
   provingTimeMillis: number;
   amount: bigint;
   withdrawalAddress: Address;
-  quotedFees: QuoteFeesResponse;
+  quotedFees: QuotedFees;
   token: Token;
   pocketMoney: bigint;
 }
@@ -157,7 +157,7 @@ export class WithdrawAction extends NoteAction {
     state: AccountStateMerkleIndexed,
     amount: bigint,
     relayerAddress: Address,
-    quotedFees: QuoteFeesResponse,
+    quotedFees: QuotedFees,
     withdrawalAddress: Address,
     expectedContractVersion: `0x${string}`,
     pocketMoney: bigint

--- a/ts/shielder-sdk/src/chain/relayer.ts
+++ b/ts/shielder-sdk/src/chain/relayer.ts
@@ -126,11 +126,7 @@ export class Relayer implements IRelayer {
               proof: Array.from(proof),
               pocket_money: pocketMoney
             },
-            quote: {
-              gas_price: quotedFees.gas_price,
-              native_token_price: quotedFees.native_token_price,
-              token_price_ratio: quotedFees.token_price_ratio
-            }
+            quote: quotedFees
           },
           (_, value: unknown) =>
             typeof value === "bigint" ? value.toString() : value

--- a/ts/shielder-sdk/src/chain/relayer.ts
+++ b/ts/shielder-sdk/src/chain/relayer.ts
@@ -11,12 +11,46 @@ const withdrawResponseSchema = z.object({
 export type WithdrawResponse = z.infer<typeof withdrawResponseSchema>;
 
 const quoteFeesResponseSchema = z.object({
+  // 8< ----------------------- >8
   base_fee: z.coerce.bigint(),
   relay_fee: z.coerce.bigint(),
-  total_fee: z.coerce.bigint()
+  total_fee: z.coerce.bigint(),
+  // 8< ----------------------- >8
+  total_cost_native: z.coerce.bigint(),
+  total_cost_fee_token: z.coerce.bigint(),
+  gas_price: z.coerce.bigint(),
+  gas_cost_native: z.coerce.bigint(),
+  gas_cost_fee_token: z.coerce.bigint(),
+  commission_native: z.coerce.bigint(),
+  commission_fee_token: z.coerce.bigint(),
+  native_token_price: z.coerce.string(),
+  native_token_unit_price: z.coerce.string(),
+  fee_token_price: z.coerce.string(),
+  fee_token_unit_price: z.coerce.string(),
+  token_price_ratio: z.coerce.string()
 });
 
 export type QuoteFeesResponse = z.infer<typeof quoteFeesResponseSchema>;
+
+export const quotedFeesFromTotalFee = (totalFee: bigint) => {
+  return {
+    base_fee: 0n,
+    relay_fee: 0n,
+    total_fee: totalFee,
+    total_cost_native: totalFee,
+    total_cost_fee_token: 0n,
+    gas_price: 0n,
+    gas_cost_native: 0n,
+    gas_cost_fee_token: 0n,
+    commission_native: 0n,
+    commission_fee_token: 0n,
+    native_token_price: "1",
+    native_token_unit_price: "1",
+    fee_token_price: "1",
+    fee_token_unit_price: "1",
+    token_price_ratio: "1"
+  };
+};
 
 export class GenericWithdrawError extends Error {
   constructor(message: string) {
@@ -40,7 +74,8 @@ export type IRelayer = {
     withdrawalAddress: `0x${string}`,
     macSalt: bigint,
     macCommitment: bigint,
-    pocketMoney: bigint
+    pocketMoney: bigint,
+    quotedFees: QuoteFeesResponse
   ) => Promise<WithdrawResponse>;
   quoteFees: () => Promise<QuoteFeesResponse>;
 };
@@ -64,7 +99,8 @@ export class Relayer implements IRelayer {
     withdrawalAddress: `0x${string}`,
     macSalt: bigint,
     macCommitment: bigint,
-    pocketMoney: bigint
+    pocketMoney: bigint,
+    quotedFees: QuoteFeesResponse
   ): Promise<WithdrawResponse> => {
     let response;
     try {
@@ -75,19 +111,26 @@ export class Relayer implements IRelayer {
         },
         body: JSON.stringify(
           {
-            expected_contract_version: expectedContractVersion,
-            amount,
-            withdraw_address: withdrawalAddress,
-            merkle_root: merkleRoot,
-            nullifier_hash: oldNullifierHash,
-            new_note: newNote,
-            mac_salt: macSalt,
-            mac_commitment: macCommitment,
-            fee_token:
-              token.type === "native" ? "Native" : { ERC20: token.address },
-            fee_amount: feeAmount,
-            proof: Array.from(proof),
-            pocket_money: pocketMoney
+            calldata: {
+              expected_contract_version: expectedContractVersion,
+              amount,
+              withdraw_address: withdrawalAddress,
+              merkle_root: merkleRoot,
+              nullifier_hash: oldNullifierHash,
+              new_note: newNote,
+              mac_salt: macSalt,
+              mac_commitment: macCommitment,
+              fee_token:
+                token.type === "native" ? "Native" : { ERC20: token.address },
+              fee_amount: feeAmount,
+              proof: Array.from(proof),
+              pocket_money: pocketMoney
+            },
+            quote: {
+              gas_price: quotedFees.gas_price,
+              native_token_price: quotedFees.native_token_price,
+              token_price_ratio: quotedFees.token_price_ratio
+            }
           },
           (_, value: unknown) =>
             typeof value === "bigint" ? value.toString() : value

--- a/ts/shielder-sdk/src/chain/relayer.ts
+++ b/ts/shielder-sdk/src/chain/relayer.ts
@@ -30,7 +30,7 @@ const quoteFeesResponseSchema = z.object({
   token_price_ratio: z.coerce.string()
 });
 
-export type QuoteFeesResponse = z.infer<typeof quoteFeesResponseSchema>;
+export type QuotedFees = z.infer<typeof quoteFeesResponseSchema>;
 
 export const quotedFeesFromTotalFee = (totalFee: bigint) => {
   return {
@@ -75,9 +75,9 @@ export type IRelayer = {
     macSalt: bigint,
     macCommitment: bigint,
     pocketMoney: bigint,
-    quotedFees: QuoteFeesResponse
+    quotedFees: QuotedFees
   ) => Promise<WithdrawResponse>;
-  quoteFees: () => Promise<QuoteFeesResponse>;
+  quoteFees: () => Promise<QuotedFees>;
 };
 
 export class Relayer implements IRelayer {
@@ -100,7 +100,7 @@ export class Relayer implements IRelayer {
     macSalt: bigint,
     macCommitment: bigint,
     pocketMoney: bigint,
-    quotedFees: QuoteFeesResponse
+    quotedFees: QuotedFees
   ): Promise<WithdrawResponse> => {
     let response;
     try {

--- a/ts/shielder-sdk/src/client/actions.ts
+++ b/ts/shielder-sdk/src/client/actions.ts
@@ -1,6 +1,5 @@
 import { Token } from "@/types";
 import {
-  QuotedFees,
   SendShielderTransaction,
   ShielderCallbacks,
   ShielderOperation
@@ -8,11 +7,7 @@ import {
 import { AccountRegistry } from "@/state/accountRegistry";
 import { Hash, PublicClient } from "viem";
 import { StateSynchronizer } from "@/state/sync/synchronizer";
-import {
-  IRelayer,
-  quotedFeesFromTotalFee,
-  QuoteFeesResponse
-} from "@/chain/relayer";
+import { IRelayer, quotedFeesFromTotalFee, QuotedFees } from "@/chain/relayer";
 import { NewAccountAction } from "@/actions/newAccount";
 import { DepositAction } from "@/actions/deposit";
 import { WithdrawAction } from "@/actions/withdraw";
@@ -37,12 +32,7 @@ export class ShielderActions {
    * @returns quoted fees for the withdraw operation
    */
   async getWithdrawFees(): Promise<QuotedFees> {
-    const fees = await this.relayer.quoteFees();
-    return {
-      baseFee: fees.base_fee,
-      relayFee: fees.relay_fee,
-      totalFee: fees.total_fee
-    };
+    return await this.relayer.quoteFees();
   }
 
   /**
@@ -79,7 +69,7 @@ export class ShielderActions {
    * Mutates the shielder state.
    * @param {Token} token - token to withdraw
    * @param {bigint} amount - amount to withdraw, in wei
-   * @param {bigint} totalFee - total fee that is deducted from amount, in wei, supposedly a sum of base fee and relay fee
+   * @param {QuotedFees} quotedFees - fee info provided by the relayer
    * @param {`0x${string}`} withdrawalAddress - public address of the recipient
    * @param {bigint} pocketMoney - amount of native token to be sent to the recipient by the relayer; only for ERC20 withdrawals
    * @returns transaction hash of the withdraw transaction
@@ -88,7 +78,7 @@ export class ShielderActions {
   async withdraw(
     token: Token,
     amount: bigint,
-    quotedFees: QuoteFeesResponse,
+    quotedFees: QuotedFees,
     withdrawalAddress: `0x${string}`,
     pocketMoney: bigint
   ) {

--- a/ts/shielder-sdk/src/client/actions.ts
+++ b/ts/shielder-sdk/src/client/actions.ts
@@ -8,7 +8,11 @@ import {
 import { AccountRegistry } from "@/state/accountRegistry";
 import { Hash, PublicClient } from "viem";
 import { StateSynchronizer } from "@/state/sync/synchronizer";
-import { IRelayer } from "@/chain/relayer";
+import {
+  IRelayer,
+  quotedFeesFromTotalFee,
+  QuoteFeesResponse
+} from "@/chain/relayer";
 import { NewAccountAction } from "@/actions/newAccount";
 import { DepositAction } from "@/actions/deposit";
 import { WithdrawAction } from "@/actions/withdraw";
@@ -84,7 +88,7 @@ export class ShielderActions {
   async withdraw(
     token: Token,
     amount: bigint,
-    totalFee: bigint,
+    quotedFees: QuoteFeesResponse,
     withdrawalAddress: `0x${string}`,
     pocketMoney: bigint
   ) {
@@ -99,7 +103,7 @@ export class ShielderActions {
           state,
           amount,
           relayerAddress,
-          totalFee,
+          quotedFees,
           withdrawalAddress,
           contractVersion,
           pocketMoney
@@ -144,7 +148,7 @@ export class ShielderActions {
           state,
           amount,
           from,
-          0n, // totalFee is 0, as it is not used in this case
+          quotedFeesFromTotalFee(0n),
           withdrawalAddress,
           contractVersion,
           0n // pocketMoney is 0, as it is not used in this case

--- a/ts/shielder-sdk/src/client/client.ts
+++ b/ts/shielder-sdk/src/client/client.ts
@@ -1,9 +1,5 @@
 import { Address } from "viem";
-import {
-  QuotedFees,
-  SendShielderTransaction,
-  ShielderCallbacks
-} from "./types";
+import { SendShielderTransaction, ShielderCallbacks } from "./types";
 import { Token } from "@/types";
 import { StateSynchronizer } from "@/state/sync/synchronizer";
 import { HistoryFetcher } from "@/state/sync/historyFetcher";
@@ -11,7 +7,7 @@ import { ShielderTransaction } from "@/state/types";
 import { AccountRegistry } from "@/state/accountRegistry";
 import { ShielderActions } from "./actions";
 import { ShielderComponents } from "./factories";
-import { QuoteFeesResponse } from "@/chain/relayer";
+import { QuotedFees } from "@/chain/relayer";
 
 export class ShielderClient {
   private accountRegistry: AccountRegistry;
@@ -101,7 +97,7 @@ export class ShielderClient {
    * @returns quoted fees for the withdraw operation
    */
   async getWithdrawFees(): Promise<QuotedFees> {
-    return this.shielderActions.getWithdrawFees();
+    return await this.shielderActions.getWithdrawFees();
   }
 
   /**
@@ -135,7 +131,7 @@ export class ShielderClient {
    * Mutates the shielder state.
    * @param {Token} token - token to withdraw
    * @param {bigint} amount - amount to withdraw, in wei
-   * @param {QuoteFeesResponse} quotedFees - fee info provided by the relayer
+   * @param {QuotedFees} quotedFees - fee info provided by the relayer
    * @param {`0x${string}`} withdrawalAddress - public address of the recipient
    * @param {bigint} pocketMoney - amount of native token to be sent to the recipient by the relayer; only for ERC20 withdrawals
    * @returns transaction hash of the withdraw transaction
@@ -144,7 +140,7 @@ export class ShielderClient {
   async withdraw(
     token: Token,
     amount: bigint,
-    quotedFees: QuoteFeesResponse,
+    quotedFees: QuotedFees,
     withdrawalAddress: Address,
     pocketMoney: bigint
   ) {

--- a/ts/shielder-sdk/src/client/client.ts
+++ b/ts/shielder-sdk/src/client/client.ts
@@ -11,6 +11,7 @@ import { ShielderTransaction } from "@/state/types";
 import { AccountRegistry } from "@/state/accountRegistry";
 import { ShielderActions } from "./actions";
 import { ShielderComponents } from "./factories";
+import { QuoteFeesResponse } from "@/chain/relayer";
 
 export class ShielderClient {
   private accountRegistry: AccountRegistry;
@@ -134,7 +135,7 @@ export class ShielderClient {
    * Mutates the shielder state.
    * @param {Token} token - token to withdraw
    * @param {bigint} amount - amount to withdraw, in wei
-   * @param {bigint} totalFee - total fee that is deducted from amount, in wei, supposedly a sum of base fee and relay fee
+   * @param {QuoteFeesResponse} quotedFees - fee info provided by the relayer
    * @param {`0x${string}`} withdrawalAddress - public address of the recipient
    * @param {bigint} pocketMoney - amount of native token to be sent to the recipient by the relayer; only for ERC20 withdrawals
    * @returns transaction hash of the withdraw transaction
@@ -143,14 +144,14 @@ export class ShielderClient {
   async withdraw(
     token: Token,
     amount: bigint,
-    totalFee: bigint,
+    quotedFees: QuoteFeesResponse,
     withdrawalAddress: Address,
     pocketMoney: bigint
   ) {
     return this.shielderActions.withdraw(
       token,
       amount,
-      totalFee,
+      quotedFees,
       withdrawalAddress,
       pocketMoney
     );

--- a/ts/shielder-sdk/src/client/types.ts
+++ b/ts/shielder-sdk/src/client/types.ts
@@ -45,13 +45,3 @@ export type SendShielderTransaction = (params: {
   value: bigint;
   gas: bigint;
 }) => Promise<`0x${string}`>;
-
-export type QuotedFees = {
-  // esimated base fee for the withdraw operation
-  baseFee: bigint;
-  // estimated relay fee for the withdraw operation
-  relayFee: bigint;
-  // total fee for the withdraw operation, is deducted from the
-  // amount to withdraw, supposedly a sum of `baseFee` and `relayFee`
-  totalFee: bigint;
-};

--- a/ts/shielder-sdk/src/index.ts
+++ b/ts/shielder-sdk/src/index.ts
@@ -1,7 +1,6 @@
 export type {
   SendShielderTransaction,
   ShielderCallbacks,
-  QuotedFees,
   ShielderOperation
 } from "@/client/types";
 export { ShielderClient } from "@/client/client";

--- a/ts/shielder-sdk/src/index.ts
+++ b/ts/shielder-sdk/src/index.ts
@@ -13,3 +13,4 @@ export {
   accountObjectSchema,
   InjectedStorageInterface
 } from "@/storage/storageSchema";
+export type { QuotedFees } from "@/chain/relayer";


### PR DESCRIPTION
1. Refactor `relay.rs` module to improve error handling.
2. Bring all methods for server responses to a common place, unify returning.
3. Extend `RelayerQuery` by quotation info.
4. Adapt CLI and SDK.