### PR TITLE
Pass both prices to the relayer

### DIFF
--- a/crates/shielder-relayer/src/fee.rs
+++ b/crates/shielder-relayer/src/fee.rs
@@ -1,0 +1,109 @@
+use alloy_primitives::U256;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use shielder_account::Token;
+use utoipa::ToSchema;
+
+#[derive(Clone, Debug, Deserialize, Serialize, ToSchema)]
+pub struct QuoteFeeQuery {
+    #[schema(value_type = Object, examples("Native", json!({"ERC20": "0x1234"})))]
+    pub fee_token: Token,
+    #[schema(value_type = String)]
+    pub pocket_money: U256,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, ToSchema)]
+pub struct FeeDetails {
+    /// The total relay cost in native token.
+    #[schema(value_type = String)]
+    pub total_cost_native: U256,
+    /// The total relay cost in fee token.
+    #[schema(value_type = String)]
+    pub total_cost_fee_token: U256,
+
+    /// Gas cost for relay call (in native token).
+    #[schema(value_type = String)]
+    pub gas_cost_native: U256,
+    /// Gas cost for relay call (in fee token).
+    #[schema(value_type = String)]
+    pub gas_cost_fee_token: U256,
+
+    /// The commission for the relayer in native token.
+    #[schema(value_type = String)]
+    pub commission_native: U256,
+    /// The commission for the relayer in fee token.
+    #[schema(value_type = String)]
+    pub commission_fee_token: U256,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, ToSchema)]
+pub struct PriceDetails {
+    /// Current gas price (in native token).
+    #[schema(value_type = String)]
+    pub gas_price: U256,
+    /// Current price of the native token (base unit, like 1 ETH or 1 BTC).
+    pub native_token_price: Decimal,
+    /// Current price of the minimal unit of the native token (like 1 wei or 1 satoshi).
+    pub native_token_unit_price: Decimal,
+    /// Current price of the fee token (base unit, like 1 ETH or 1 BTC).
+    pub fee_token_price: Decimal,
+    /// Current price of the minimal unit of the fee token (like 1 wei or 1 satoshi).
+    pub fee_token_unit_price: Decimal,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, ToSchema)]
+pub struct QuoteFeeResponse {
+    // 8< ----------------------------------------------------- >8  TO BE REMOVED SOON
+    /// The fee used as a contract input by the relayer.
+    #[schema(value_type = String)]
+    pub total_fee: U256,
+    /// The estimation of a base fee for relay call.
+    #[schema(value_type = String)]
+    pub base_fee: U256,
+    /// The estimation of a relay fee for relay call.
+    #[schema(value_type = String)]
+    pub relay_fee: U256,
+    // 8< ----------------------------------------------------- >8
+    pub fee_details: FeeDetails,
+    pub price_details: PriceDetails,
+}
+
+pub fn compute_fee(
+    gas_price: U256,
+    required_gas: U256,
+    pocket_money: U256,
+    commission: u32,
+    native_token_unit_price: Decimal,
+    fee_token_unit_price: Decimal,
+) -> Result<FeeDetails, &'static str> {
+    // Gas cost in native token.
+    let gas_cost_native = required_gas * gas_price;
+    // Actual cost of performing the relay.
+    let relayer_cost_native = gas_cost_native + pocket_money;
+    // Relay commission.
+    let commission_native = relayer_cost_native * U256::from(commission) / U256::from(100);
+    // Total cost for the user.
+    let total_cost_native = relayer_cost_native + commission_native;
+
+    let native_to_fee_ratio = native_token_unit_price / fee_token_unit_price;
+
+    Ok(FeeDetails {
+        total_cost_native,
+        total_cost_fee_token: scale_u256(total_cost_native, native_to_fee_ratio)?,
+        gas_cost_native,
+        gas_cost_fee_token: scale_u256(gas_cost_native, native_to_fee_ratio)?,
+        commission_native,
+        commission_fee_token: scale_u256(commission_native, native_to_fee_ratio)?,
+    })
+}
+
+const RELATIVE_PRICE_DIGITS: u32 = 20;
+
+pub fn scale_u256(a: U256, b: Decimal) -> Result<U256, &'static str> {
+    let b = b
+        .round_sf(RELATIVE_PRICE_DIGITS)
+        .ok_or("Arithmetic error")?;
+    let mantissa: U256 = b.mantissa().try_into().map_err(|_| "Arithmetic error")?;
+    let scale = U256::pow(U256::from(10), U256::from(b.scale()));
+    Ok(a * mantissa / scale)
+}

--- a/crates/shielder-relayer/src/main.rs
+++ b/crates/shielder-relayer/src/main.rs
@@ -49,6 +49,7 @@ pub struct AppState {
     pub token_config: Vec<TokenInfo>,
     pub quote_cache: QuoteCache,
     pub max_pocket_money: U256,
+    pub service_fee_percent: u32,
 }
 
 struct Signers {
@@ -162,6 +163,7 @@ async fn start_main_server(config: &ServerConfig, signers: Signers, prices: Pric
         prices,
         quote_cache,
         max_pocket_money: config.operations.max_pocket_money,
+        service_fee_percent: config.operations.service_fee_percent,
     };
 
     let (router, api) = OpenApiRouter::with_openapi(ApiDoc::openapi())

--- a/crates/shielder-relayer/src/quote_cache.rs
+++ b/crates/shielder-relayer/src/quote_cache.rs
@@ -13,10 +13,10 @@ pub struct CachedQuote {
     pub fee_token: Token,
     /// Gas price (in native token) at the quotation moment.
     pub gas_price: U256,
-    /// Price of the native token (base unit, like 1 ETH or 1 BTC) at the quotation moment.
-    pub native_token_price: Decimal,
-    /// Ratio between the native token and the fee token at the quotation moment.
-    pub token_price_ratio: Decimal,
+    /// Price of the minimal unit of the native token (like 1 wei or 1 satoshi) at the quotation moment.
+    pub native_token_unit_price: Decimal,
+    /// Price of the minimal unit of the fee token (like 1 wei or 1 satoshi) at the quotation moment.
+    pub fee_token_unit_price: Decimal,
 }
 
 /// Service storing quotations with a certain validity.
@@ -97,8 +97,8 @@ mod tests {
         CachedQuote {
             fee_token: Token::Native,
             gas_price: U256::from(1),
-            native_token_price: Decimal::ONE,
-            token_price_ratio: Decimal::ONE,
+            native_token_unit_price: Decimal::ONE,
+            fee_token_unit_price: Decimal::ONE,
         }
     }
 

--- a/crates/shielder-relayer/src/relay/fee_checking_tests.rs
+++ b/crates/shielder-relayer/src/relay/fee_checking_tests.rs
@@ -26,6 +26,7 @@ fn app_state() -> AppState {
         relay_gas: Default::default(),
         quote_cache: QuoteCache::new(Default::default()),
         max_pocket_money: Default::default(),
+        service_fee_percent: Default::default(),
     }
 }
 

--- a/crates/shielder-relayer/src/relay/mod.rs
+++ b/crates/shielder-relayer/src/relay/mod.rs
@@ -162,8 +162,8 @@ async fn check_quote_validity(
     let cached_quote = CachedQuote {
         fee_token: query.calldata.fee_token,
         gas_price: query.quote.gas_price,
-        native_token_price: query.quote.native_token_price,
-        token_price_ratio: query.quote.token_price_ratio,
+        native_token_unit_price: query.quote.native_token_unit_price,
+        fee_token_unit_price: query.quote.fee_token_unit_price,
     };
     match app_state.quote_cache.is_quote_valid(&cached_quote).await {
         true => Ok(()),

--- a/crates/shielder-relayer/tests/component_tests.rs
+++ b/crates/shielder-relayer/tests/component_tests.rs
@@ -1,6 +1,6 @@
 use reqwest::{Response, StatusCode};
 use rust_decimal::Decimal;
-use shielder_relayer::{RelayQuote, RelayResponse, SimpleServiceResponse};
+use shielder_relayer::{RelayResponse, SimpleServiceResponse};
 
 use crate::utils::{
     config::{NodeRpcUrl, RelayerSigner, ShielderContract, TestConfig, POOR_ADDRESS, SIGNER},
@@ -110,8 +110,8 @@ async fn relay_query_without_quote_before_fails() {
 async fn server_returns_quotation() {
     let context = TestContext::new(standard_config()).await;
     let quote = context.quote().await;
-    assert_eq!(quote.native_token_price, Decimal::ONE);
-    assert_eq!(quote.token_price_ratio, Decimal::ONE);
+    assert_eq!(quote.native_token_unit_price, Decimal::new(1, 18));
+    assert_eq!(quote.fee_token_unit_price, Decimal::new(1, 18));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/ts/shielder-sdk/src/chain/relayer.ts
+++ b/ts/shielder-sdk/src/chain/relayer.ts
@@ -16,18 +16,22 @@ const quoteFeesResponseSchema = z.object({
   relay_fee: z.coerce.bigint(),
   total_fee: z.coerce.bigint(),
   // 8< ----------------------- >8
-  total_cost_native: z.coerce.bigint(),
-  total_cost_fee_token: z.coerce.bigint(),
-  gas_price: z.coerce.bigint(),
-  gas_cost_native: z.coerce.bigint(),
-  gas_cost_fee_token: z.coerce.bigint(),
-  commission_native: z.coerce.bigint(),
-  commission_fee_token: z.coerce.bigint(),
-  native_token_price: z.coerce.string(),
-  native_token_unit_price: z.coerce.string(),
-  fee_token_price: z.coerce.string(),
-  fee_token_unit_price: z.coerce.string(),
-  token_price_ratio: z.coerce.string()
+  fee_details: z.object({
+    total_cost_native: z.coerce.bigint(),
+    total_cost_fee_token: z.coerce.bigint(),
+    gas_cost_native: z.coerce.bigint(),
+    gas_cost_fee_token: z.coerce.bigint(),
+    commission_native: z.coerce.bigint(),
+    commission_fee_token: z.coerce.bigint()
+  }),
+  price_details: z.object({
+    gas_price: z.coerce.bigint(),
+    native_token_price: z.coerce.string(),
+    native_token_unit_price: z.coerce.string(),
+    fee_token_price: z.coerce.string(),
+    fee_token_unit_price: z.coerce.string(),
+    token_price_ratio: z.coerce.string()
+  })
 });
 
 export type QuotedFees = z.infer<typeof quoteFeesResponseSchema>;
@@ -37,18 +41,22 @@ export const quotedFeesFromTotalFee = (totalFee: bigint) => {
     base_fee: 0n,
     relay_fee: 0n,
     total_fee: totalFee,
-    total_cost_native: totalFee,
-    total_cost_fee_token: 0n,
-    gas_price: 0n,
-    gas_cost_native: 0n,
-    gas_cost_fee_token: 0n,
-    commission_native: 0n,
-    commission_fee_token: 0n,
-    native_token_price: "1",
-    native_token_unit_price: "1",
-    fee_token_price: "1",
-    fee_token_unit_price: "1",
-    token_price_ratio: "1"
+    fee_details: {
+      total_cost_native: totalFee,
+      total_cost_fee_token: 0n,
+      gas_cost_native: 0n,
+      gas_cost_fee_token: 0n,
+      commission_native: 0n,
+      commission_fee_token: 0n
+    },
+    price_details: {
+      gas_price: 0n,
+      native_token_price: "1",
+      native_token_unit_price: "1",
+      fee_token_price: "1",
+      fee_token_unit_price: "1",
+      token_price_ratio: "1"
+    }
   };
 };
 
@@ -127,9 +135,11 @@ export class Relayer implements IRelayer {
               pocket_money: pocketMoney
             },
             quote: {
-              gas_price: quotedFees.gas_price,
-              native_token_price: quotedFees.native_token_price,
-              token_price_ratio: quotedFees.token_price_ratio
+              gas_price: quotedFees.price_details.gas_price,
+              native_token_unit_price:
+                quotedFees.price_details.native_token_unit_price,
+              fee_token_unit_price:
+                quotedFees.price_details.fee_token_unit_price
             }
           },
           (_, value: unknown) =>


### PR DESCRIPTION
1. Stop hardcoding service commission (use the one from configuration)
2. Instead of passing token price and ratio, pass both token unit prices.
3. Move price computing logic to lib.