### PR TITLE
Enforce recharge

### DIFF
--- a/crates/shielder-relayer/src/main.rs
+++ b/crates/shielder-relayer/src/main.rs
@@ -130,7 +130,6 @@ async fn start_main_server(config: &ServerConfig, signers: Signers, prices: Pric
     let fee_destination = signer(&config.keys.fee_destination_key)?;
     let fee_destination_address = fee_destination.address();
 
-    error!("KURWA - START");
     ensure_signers_have_funds(
         &config.chain.node_rpc_url,
         fee_destination.clone(),
@@ -138,7 +137,6 @@ async fn start_main_server(config: &ServerConfig, signers: Signers, prices: Pric
         &config.operations,
     )
     .await?;
-    error!("KURWA - STOP");
 
     let report_for_recharge = start_recharging_worker(
         config.chain.node_rpc_url.clone(),
@@ -206,20 +204,14 @@ async fn ensure_signers_have_funds(
     let cornucopia_address = cornucopia.address();
     let provider = create_provider_with_signer(node_rpc_urk, cornucopia).await?;
     for relayer in &signers.addresses {
-        error!("CHUJ");
-        let e = try_recharging_relayer(
+        try_recharging_relayer(
             &provider,
             *relayer,
             cornucopia_address,
             operational_config.recharge_threshold,
             operational_config.recharge_amount,
         )
-        .await;
-        error!("CHUJ - STOP");
-
-        if let Err(err) = e {
-            error!("Recharging relayer failed: {err:?}");
-        }
+        .await?;
     }
     Ok(())
 }

--- a/crates/shielder-relayer/src/main.rs
+++ b/crates/shielder-relayer/src/main.rs
@@ -147,8 +147,7 @@ async fn start_main_server(config: &ServerConfig, signers: Signers, prices: Pric
         &signers.addresses,
         config.operations.recharge_threshold,
         config.operations.recharge_amount,
-    )
-    .await;
+    );
 
     let quote_cache = QuoteCache::new(config.operations.quote_validity);
     tokio::spawn(garbage_collector_worker(quote_cache.clone()));

--- a/crates/shielder-relayer/src/main.rs
+++ b/crates/shielder-relayer/src/main.rs
@@ -124,10 +124,6 @@ async fn start_metrics_server(config: &ServerConfig, balances: Balances) -> Resu
 }
 
 async fn start_main_server(config: &ServerConfig, signers: Signers, prices: Prices) -> Result<()> {
-    let address = config.network.main_address();
-    let listener = tokio::net::TcpListener::bind(address.clone()).await?;
-    info!("Listening on {address}");
-
     let fee_destination = signer(&config.keys.fee_destination_key)?;
     let fee_destination_address = fee_destination.address();
 
@@ -180,6 +176,11 @@ async fn start_main_server(config: &ServerConfig, signers: Signers, prices: Pric
     let app = router
         .merge(SwaggerUi::new("/api").url("/api/openapi.json", api.clone()))
         .layer(CorsLayer::permissive());
+
+    let address = config.network.main_address();
+    let listener = tokio::net::TcpListener::bind(address.clone()).await?;
+    info!("Server is ready. Listening on {address}");
+
     Ok(axum::serve(listener, app).await?)
 }
 

--- a/crates/shielder-relayer/src/main.rs
+++ b/crates/shielder-relayer/src/main.rs
@@ -7,23 +7,26 @@ use axum::{middleware, routing::get, Router};
 use price_feed::{start_price_feed, Prices};
 use shielder_contract::{
     alloy_primitives::{Address, U256},
-    providers::create_provider_with_nonce_caching_signer,
+    providers::{create_provider_with_nonce_caching_signer, create_provider_with_signer},
     ConnectionPolicy, ShielderUser,
 };
 use shielder_relayer::TokenInfo;
 use tower_http::cors::CorsLayer;
-use tracing::info;
+use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 use utoipa::OpenApi;
 use utoipa_axum::{router::OpenApiRouter, routes};
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::{
-    config::{resolve_config, ChainConfig, KeyConfig, LoggingFormat, NoncePolicy, ServerConfig},
+    config::{
+        resolve_config, ChainConfig, KeyConfig, LoggingFormat, NoncePolicy, OperationalConfig,
+        ServerConfig,
+    },
     metrics::{prometheus_endpoint, setup_metrics_handle},
     monitor::{balance_monitor::balance_monitor, Balances},
     quote_cache::{garbage_collector_worker, QuoteCache},
-    recharge::start_recharging_worker,
+    recharge::{start_recharging_worker, try_recharging_relayer},
     relay::Taskmaster,
 };
 
@@ -127,6 +130,16 @@ async fn start_main_server(config: &ServerConfig, signers: Signers, prices: Pric
     let fee_destination = signer(&config.keys.fee_destination_key)?;
     let fee_destination_address = fee_destination.address();
 
+    error!("KURWA - START");
+    ensure_signers_have_funds(
+        &config.chain.node_rpc_url,
+        fee_destination.clone(),
+        &signers,
+        &config.operations,
+    )
+    .await?;
+    error!("KURWA - STOP");
+
     let report_for_recharge = start_recharging_worker(
         config.chain.node_rpc_url.clone(),
         fee_destination,
@@ -182,6 +195,33 @@ async fn start_main_server(config: &ServerConfig, signers: Signers, prices: Pric
     info!("Server is ready. Listening on {address}");
 
     Ok(axum::serve(listener, app).await?)
+}
+
+async fn ensure_signers_have_funds(
+    node_rpc_urk: &str,
+    cornucopia: PrivateKeySigner,
+    signers: &Signers,
+    operational_config: &OperationalConfig,
+) -> Result<()> {
+    let cornucopia_address = cornucopia.address();
+    let provider = create_provider_with_signer(node_rpc_urk, cornucopia).await?;
+    for relayer in &signers.addresses {
+        error!("CHUJ");
+        let e = try_recharging_relayer(
+            &provider,
+            *relayer,
+            cornucopia_address,
+            operational_config.recharge_threshold,
+            operational_config.recharge_amount,
+        )
+        .await;
+        error!("CHUJ - STOP");
+
+        if let Err(err) = e {
+            error!("Recharging relayer failed: {err:?}");
+        }
+    }
+    Ok(())
 }
 
 fn init_logging(format: LoggingFormat) -> Result<()> {

--- a/crates/shielder-relayer/src/monitor/balance_monitor.rs
+++ b/crates/shielder-relayer/src/monitor/balance_monitor.rs
@@ -34,7 +34,7 @@ pub async fn balance_monitor(
     }
 }
 
-async fn set_balance(balances: &Balances, address: Address, balance: Option<U256>) {
+pub async fn set_balance(balances: &Balances, address: Address, balance: Option<U256>) {
     *balances
         .get(&address)
         .expect("Map should be already intialized")

--- a/crates/shielder-relayer/src/recharge.rs
+++ b/crates/shielder-relayer/src/recharge.rs
@@ -4,11 +4,10 @@ use alloy_signer_local::PrivateKeySigner;
 use anyhow::{bail, Result};
 use shielder_contract::{
     alloy_primitives::{Address, U256},
-    providers::create_provider_with_nonce_caching_signer,
+    providers::create_provider_with_signer,
 };
 use tokio::sync::mpsc::{self, Receiver as MPSCReceiver, Sender as MPSCSender};
 use tracing::{error, info};
-use shielder_contract::providers::create_provider_with_signer;
 
 pub async fn start_recharging_worker(
     node_rpc_url: String,

--- a/crates/shielder-relayer/src/recharge.rs
+++ b/crates/shielder-relayer/src/recharge.rs
@@ -8,6 +8,7 @@ use shielder_contract::{
 };
 use tokio::sync::mpsc::{self, Receiver as MPSCReceiver, Sender as MPSCSender};
 use tracing::{error, info};
+use shielder_contract::providers::create_provider_with_signer;
 
 pub async fn start_recharging_worker(
     node_rpc_url: String,
@@ -44,7 +45,7 @@ async fn recharging_worker(
     recharge_amount: U256,
 ) -> Result<()> {
     let cornucopia_address = cornucopia.address();
-    let provider = create_provider_with_nonce_caching_signer(&node_rpc_url, cornucopia).await?;
+    let provider = create_provider_with_signer(&node_rpc_url, cornucopia).await?;
     while let Some(relayer) = relay_reports.recv().await {
         if let Err(err) = try_recharging_relayer(
             &provider,

--- a/crates/shielder-relayer/src/recharge.rs
+++ b/crates/shielder-relayer/src/recharge.rs
@@ -9,7 +9,7 @@ use shielder_contract::{
 use tokio::sync::mpsc::{self, Receiver as MPSCReceiver, Sender as MPSCSender};
 use tracing::{error, info};
 
-pub async fn start_recharging_worker(
+pub fn start_recharging_worker(
     node_rpc_url: String,
     cornucopia: PrivateKeySigner,
     relay_workers: &[Address],
@@ -24,14 +24,6 @@ pub async fn start_recharging_worker(
         recharge_threshold,
         recharge_amount,
     ));
-
-    // Trigger the recharging worker to ensure that every worker has funds.
-    for relayer in relay_workers {
-        relay_report_sender
-            .send(*relayer)
-            .await
-            .expect("Relay report channel closed");
-    }
 
     relay_report_sender
 }

--- a/crates/shielder-relayer/src/recharge.rs
+++ b/crates/shielder-relayer/src/recharge.rs
@@ -70,7 +70,7 @@ pub async fn try_recharging_relayer(
     cornucopia_address: Address,
     recharge_threshold: U256,
     recharge_amount: U256,
-) -> Result<()> {
+) -> Result<U256> {
     let relayer_balance = match provider.get_balance(relayer).await {
         Ok(balance) => balance,
         Err(err) => {
@@ -82,10 +82,11 @@ pub async fn try_recharging_relayer(
 
     if relayer_balance < recharge_threshold {
         info!("Relayer {relayer} has insufficient funds ({relayer_balance}). Recharging with {recharge_amount}.");
-        recharge_relayer(provider, relayer, cornucopia_address, recharge_amount).await
+        recharge_relayer(provider, relayer, cornucopia_address, recharge_amount).await?;
+        Ok(recharge_amount + relayer_balance)
     } else {
         info!("Relayer {relayer} has sufficient funds: {relayer_balance} - no need to recharge.");
-        Ok(())
+        Ok(relayer_balance)
     }
 }
 

--- a/crates/shielder-relayer/tests/component_tests.rs
+++ b/crates/shielder-relayer/tests/component_tests.rs
@@ -45,34 +45,6 @@ async fn in_correct_setting_service_is_healthy_and_signers_have_funds() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn when_cannot_connect_to_chain_service_is_not_healthy_and_signers_have_no_balance() {
-    let test_context = TestContext::new(TestConfig {
-        node_rpc_url: NodeRpcUrl::Unavailable,
-        ..standard_config()
-    })
-    .await;
-
-    let health_response = test_context.reach_health().await;
-    ctx_assert_eq!(
-        health_response.status(),
-        StatusCode::SERVICE_UNAVAILABLE,
-        test_context
-    );
-    ctx_assert!(
-        simple_payload(health_response)
-            .await
-            .starts_with("Cannot reach RPC node"),
-        test_context
-    );
-
-    let metrics = test_context.get_metrics().await;
-    ctx_assert!(
-        metrics.contains(&format!("signer_balances{{address=\"{SIGNER}\"}} 0")),
-        test_context
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn when_relayer_signer_does_not_have_enough_funds_service_is_healthy() {
     let config = TestConfig {
         relayer_signer: RelayerSigner::NotEndowed,

--- a/crates/shielder-relayer/tests/component_tests.rs
+++ b/crates/shielder-relayer/tests/component_tests.rs
@@ -44,29 +44,6 @@ async fn in_correct_setting_service_is_healthy_and_signers_have_funds() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn when_relayer_signer_does_not_have_enough_funds_service_is_healthy() {
-    let config = TestConfig {
-        relayer_signer: RelayerSigner::NotEndowed,
-        ..standard_config()
-    };
-    let test_context = TestContext::new(config).await;
-
-    let health_response = test_context.reach_health().await;
-    ctx_assert!(health_response.status().is_success(), test_context);
-    ctx_assert_eq!(
-        simple_payload(health_response).await,
-        "Healthy",
-        test_context
-    );
-
-    let metrics = test_context.get_metrics().await;
-    ctx_assert!(
-        metrics.contains(&format!("signer_balances{{address=\"{POOR_ADDRESS}\"}} 0")),
-        test_context
-    );
-}
-
 #[parameterized(token = { Token::Native, Token::ERC20(ERC20_ADDRESS) })]
 #[parameterized_macro(tokio::test(flavor = "multi_thread"))]
 async fn relay_query_without_quote_before_fails(token: Token) {

--- a/crates/shielder-relayer/tests/component_tests.rs
+++ b/crates/shielder-relayer/tests/component_tests.rs
@@ -31,7 +31,7 @@ async fn in_correct_setting_service_is_healthy_and_signers_have_funds() {
 
     let metrics = test_context.get_metrics().await;
     ctx_assert!(
-        metrics.contains(&format!("signer_balances{{address=\"{SIGNER}\"}} 10000")),
+        metrics.contains(&format!("signer_balances{{address=\"{SIGNER}\"}} 20")),
         test_context
     );
 }

--- a/crates/shielder-relayer/tests/utils/config.rs
+++ b/crates/shielder-relayer/tests/utils/config.rs
@@ -7,22 +7,18 @@ pub const FEE_DESTINATION: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 /// Corresponding private key.
 pub const FEE_DESTINATION_KEY: &str =
     "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
-/// Public key of another already endowed account on the test network.
-pub const SIGNER: &str = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+/// Public key of an account with no funds.
+pub const SIGNER: &str = "0x5e9428AC5Cf0FA8822372D8FeA88d548dc3F2Ef3";
 /// Corresponding private key.
-pub const SIGNER_KEY: &str = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
-/// Private key of an account with no funds.
-pub const POOR_ADDRESS_SIGNING_KEY: &str =
-    "0xfb50646599b16cb2e58b158f4b54d85a29d5fe4e210c6b6d5e0717dccd7c7584";
-/// Corresponding address.
-pub const POOR_ADDRESS: &str = "0x5e9428AC5Cf0FA8822372D8FeA88d548dc3F2Ef3";
+pub const SIGNER_KEY: &str = "0xfb50646599b16cb2e58b158f4b54d85a29d5fe4e210c6b6d5e0717dccd7c7584";
 
 fn get_env(name: &str) -> String {
     env::var(name).unwrap_or_else(|_| panic!("{name} env var is not set"))
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub enum ShielderContract {
+    #[default]
     Accepting,
     Reverting,
 }
@@ -37,23 +33,9 @@ impl ShielderContract {
     }
 }
 
-#[derive(Copy, Clone)]
-pub enum RelayerSigner {
-    Endowed,
-    NotEndowed,
-}
-
-impl RelayerSigner {
-    pub fn signing_key(&self) -> String {
-        match self {
-            RelayerSigner::Endowed => SIGNER_KEY.to_string(),
-            RelayerSigner::NotEndowed => POOR_ADDRESS_SIGNING_KEY.to_string(),
-        }
-    }
-}
-
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub enum NodeRpcUrl {
+    #[default]
     Valid,
     Unavailable,
 }
@@ -67,9 +49,8 @@ impl NodeRpcUrl {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct TestConfig {
     pub shielder_contract: ShielderContract,
-    pub relayer_signer: RelayerSigner,
     pub node_rpc_url: NodeRpcUrl,
 }

--- a/crates/shielder-relayer/tests/utils/mod.rs
+++ b/crates/shielder-relayer/tests/utils/mod.rs
@@ -21,7 +21,7 @@ use testcontainers::{
 use crate::{
     ctx_assert,
     utils::{
-        config::{TestConfig, BASE_URL, FEE_DESTINATION, FEE_DESTINATION_KEY},
+        config::{TestConfig, BASE_URL, FEE_DESTINATION},
         relayer_image::RelayerImage,
     },
 };
@@ -56,8 +56,6 @@ impl TestContext {
             metrics_port,
             test_config.node_rpc_url.url(),
             test_config.shielder_contract.address(),
-            FEE_DESTINATION_KEY.to_string(),
-            test_config.relayer_signer.signing_key(),
             vec![
                 TokenInfo {
                     kind: TokenKind::Native,
@@ -78,6 +76,10 @@ impl TestContext {
             relayer_port: port,
             relayer_metrics_port: metrics_port,
         }
+    }
+
+    pub async fn default() -> Self {
+        Self::new(Default::default()).await
     }
 
     pub async fn quote(&self, fee_token: Token) -> RelayQuote {

--- a/crates/shielder-relayer/tests/utils/relayer_image.rs
+++ b/crates/shielder-relayer/tests/utils/relayer_image.rs
@@ -6,6 +6,8 @@ use shielder_relayer::{
 };
 use testcontainers::{core::WaitFor, Image};
 
+use crate::utils::config::{FEE_DESTINATION_KEY, SIGNER_KEY};
+
 /// Wrapper around `shielder-relayer` Docker image.
 ///
 /// # Building image
@@ -26,8 +28,6 @@ impl RelayerImage {
         metrics_port: u16,
         node_rpc_url: String,
         shielder_address: String,
-        fee_destination_key: String,
-        signing_key: String,
         token_config: Vec<TokenInfo>,
     ) -> Self {
         Self {
@@ -39,8 +39,11 @@ impl RelayerImage {
                 ),
                 (NODE_RPC_URL_ENV.to_string(), node_rpc_url),
                 (SHIELDER_CONTRACT_ADDRESS_ENV.to_string(), shielder_address),
-                (FEE_DESTINATION_KEY_ENV.to_string(), fee_destination_key),
-                (RELAYER_SIGNING_KEYS_ENV.to_string(), signing_key),
+                (
+                    FEE_DESTINATION_KEY_ENV.to_string(),
+                    FEE_DESTINATION_KEY.to_string(),
+                ),
+                (RELAYER_SIGNING_KEYS_ENV.to_string(), SIGNER_KEY.to_string()),
                 (
                     TOKEN_CONFIG_ENV.to_string(),
                     serde_json::to_string(&token_config).unwrap(),

--- a/tooling-e2e-tests/utils.sh
+++ b/tooling-e2e-tests/utils.sh
@@ -167,6 +167,7 @@ erc20_balance() {
 start_relayer() {
   cd "${ROOT_DIR}/crates/shielder-relayer/"
   make run &>> output.log
+  sleep 5 # Wait for the relayer to fund the signer accounts - temporary solution, better one incoming soon!
   cd "${ROOT_DIR}"
 
   log_progress "✅ Relayer started"


### PR DESCRIPTION
1. Ensure all relay workers have funds before starting the service.
2. In e2e tests - sleep 5 seconds before doing healthcheck on relayer (so it has enough time to do the funding). This is a temporary workaround. In the next PR I want to introduce docker-native service healthchecks.
3. Update metrics right after funding workers.
4. Remove two component tests. If feasible, I will add some tests that the container didn't start if the conditions do not allow for funding workers. Tbd soon
