### PR TITLE
Correctly parse relayer signer balances

### DIFF
--- a/crates/shielder-relayer/src/metrics.rs
+++ b/crates/shielder-relayer/src/metrics.rs
@@ -1,4 +1,4 @@
-use std::{ops::Div, time::Instant};
+use std::time::Instant;
 
 use anyhow::Result;
 use axum::{
@@ -7,8 +7,6 @@ use axum::{
     response::IntoResponse,
 };
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
-use rust_decimal::Decimal;
-use shielder_contract::alloy_primitives::U256;
 use shielder_setup::native_token::NATIVE_TOKEN_DECIMALS;
 
 use crate::monitor::{healthy, Balances};

--- a/crates/shielder-relayer/tests/relay_tests.rs
+++ b/crates/shielder-relayer/tests/relay_tests.rs
@@ -70,6 +70,7 @@ async fn metrics_register_withdrawals() {
         metrics.contains("# TYPE withdraw_success counter\nwithdraw_success 2"),
         context
     );
+    println!("metrics: {}", metrics);
     ctx_assert!(
         metrics.contains(&format!(
             "signer_balances{{address=\"{}\"}} 19.99",

--- a/crates/shielder-relayer/tests/relay_tests.rs
+++ b/crates/shielder-relayer/tests/relay_tests.rs
@@ -1,6 +1,9 @@
+use std::time::Duration;
+
 use parameterized::parameterized;
 use reqwest::StatusCode;
 use shielder_account::Token;
+use tokio::time::sleep;
 
 use crate::utils::{
     config::{ShielderContract, TestConfig},
@@ -60,9 +63,18 @@ async fn metrics_register_withdrawals() {
     context.relay_with_quote(Token::Native).await;
     context.relay_with_quote(Token::ERC20(ERC20_ADDRESS)).await;
 
+    sleep(Duration::from_millis(1500)).await; // Metrics should be refreshed after 1 second.
+
     let metrics = context.get_metrics().await;
     ctx_assert!(
         metrics.contains("# TYPE withdraw_success counter\nwithdraw_success 2"),
+        context
+    );
+    ctx_assert!(
+        metrics.contains(&format!(
+            "signer_balances{{address=\"{}\"}} 19.99",
+            context.signer.address()
+        )),
         context
     );
 }

--- a/crates/shielder-relayer/tests/utils/config.rs
+++ b/crates/shielder-relayer/tests/utils/config.rs
@@ -7,6 +7,8 @@ pub const FEE_DESTINATION: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 /// Corresponding private key.
 pub const FEE_DESTINATION_KEY: &str =
     "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+/// How often to check signer's balance - 1 second.
+pub const BALANCE_MONITOR_INTERVAL: &str = "1";
 
 fn get_env(name: &str) -> String {
     env::var(name).unwrap_or_else(|_| panic!("{name} env var is not set"))

--- a/crates/shielder-relayer/tests/utils/mod.rs
+++ b/crates/shielder-relayer/tests/utils/mod.rs
@@ -22,7 +22,7 @@ use testcontainers::{
 use crate::{
     ctx_assert,
     utils::{
-        config::{TestConfig, BASE_URL, FEE_DESTINATION},
+        config::{TestConfig, BALANCE_MONITOR_INTERVAL, BASE_URL, FEE_DESTINATION},
         relayer_image::RelayerImage,
     },
 };
@@ -74,6 +74,7 @@ impl TestContext {
                     price_provider: PriceProvider::Static(Decimal::ONE),
                 },
             ],
+            BALANCE_MONITOR_INTERVAL.to_string(),
         ));
 
         Self {

--- a/crates/shielder-relayer/tests/utils/relayer_image.rs
+++ b/crates/shielder-relayer/tests/utils/relayer_image.rs
@@ -1,8 +1,9 @@
 use std::{borrow::Cow, collections::HashMap, fmt::Display};
 
 use shielder_relayer::{
-    TokenInfo, FEE_DESTINATION_KEY_ENV, NODE_RPC_URL_ENV, RELAYER_METRICS_PORT_ENV,
-    RELAYER_PORT_ENV, RELAYER_SIGNING_KEYS_ENV, SHIELDER_CONTRACT_ADDRESS_ENV, TOKEN_CONFIG_ENV,
+    TokenInfo, BALANCE_MONITOR_INTERVAL_ENV, FEE_DESTINATION_KEY_ENV, NODE_RPC_URL_ENV,
+    RELAYER_METRICS_PORT_ENV, RELAYER_PORT_ENV, RELAYER_SIGNING_KEYS_ENV,
+    SHIELDER_CONTRACT_ADDRESS_ENV, TOKEN_CONFIG_ENV,
 };
 use testcontainers::{core::WaitFor, Image};
 
@@ -30,6 +31,7 @@ impl RelayerImage {
         shielder_address: String,
         signer_key: String,
         token_config: Vec<TokenInfo>,
+        balance_monitor_interval: String,
     ) -> Self {
         Self {
             env_vars: HashMap::from([
@@ -48,6 +50,10 @@ impl RelayerImage {
                 (
                     TOKEN_CONFIG_ENV.to_string(),
                     serde_json::to_string(&token_config).unwrap(),
+                ),
+                (
+                    BALANCE_MONITOR_INTERVAL_ENV.to_string(),
+                    balance_monitor_interval,
                 ),
             ]),
         }


### PR DESCRIPTION
1. Do not use integer division. Do shifting on a raw string (to avoid any problems with `U256` -> `u128`/`u64` conversions)
2. Add a test for metrics format