### PR TITLE
Add `newNote` to `ShielderTransaction`

### DIFF
--- a/ts/shielder-sdk/__tests/state/sync/chainStateTransition.test.ts
+++ b/ts/shielder-sdk/__tests/state/sync/chainStateTransition.test.ts
@@ -102,7 +102,8 @@ describe("ChainStateTransition", () => {
         amount: 50n,
         txHash: "0x123",
         block: 1n,
-        token: nativeToken()
+        token: nativeToken(),
+        newNote: Scalar.fromBigint(789n),
       });
 
       expect(mockNullifierBlock).toHaveBeenCalledWith(

--- a/ts/shielder-sdk/package.json
+++ b/ts/shielder-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardinal-cryptography/shielder-sdk",
-  "version": "0.2.0-beta.7",
+  "version": "0.2.0-beta.8",
   "description": "A web package for interacting with Shielder, a part of zkOS privacy engine.",
   "license": "Apache-2.0",
   "keywords": [

--- a/ts/shielder-sdk/src/state/sync/chainStateTransition.ts
+++ b/ts/shielder-sdk/src/state/sync/chainStateTransition.ts
@@ -1,6 +1,7 @@
 import { IContract, NoteEvent } from "@/chain/contract";
 import {
   CryptoClient,
+  Scalar,
   scalarToBigint
 } from "@cardinal-cryptography/shielder-sdk-crypto";
 import { LocalStateTransition } from "@/state/localStateTransition";
@@ -105,6 +106,7 @@ const eventToTransaction = (
     txHash: event.txHash,
     block: event.block,
     token,
-    pocketMoney: event.pocketMoney
+    pocketMoney: event.pocketMoney,
+    newNote: Scalar.fromBigint(event.newNote)
   };
 };

--- a/ts/shielder-sdk/src/state/types.ts
+++ b/ts/shielder-sdk/src/state/types.ts
@@ -41,4 +41,5 @@ export type ShielderTransaction = {
   block: bigint;
   token: Token;
   pocketMoney?: bigint;
+  newNote: Scalar;
 };


### PR DESCRIPTION
actually, it seems that we could/should unify `NoteEvent` with `ShielderTransaction`, but I don't want to do it without @kroist ; thus I introduced only a required change