### PR TITLE
Support etherscan

### DIFF
--- a/.github/workflows/manual-deploy-contract.yml
+++ b/.github/workflows/manual-deploy-contract.yml
@@ -42,17 +42,17 @@ jobs:
           if [ "${{ github.event.inputs.environment }}" == "dev" ]; then
             echo "PRIVATE_KEY=${{ secrets.CI_TESTNET_DEPLOYER_PRIVATE_KEY }}" >> $GITHUB_ENV
             echo "NETWORK=https://rpc.alephzero-testnet.gelato.digital" >> $GITHUB_ENV
-            echo "EXPLORER_URL=https://evm-explorer-testnet.alephzero.org/api" >> $GITHUB_ENV
+            echo "BLOCKSCOUT_URL=https://evm-explorer-testnet.alephzero.org/api" >> $GITHUB_ENV
           elif [ "${{ github.event.inputs.environment }}" == "stage" ]; then
             echo "OWNER_ADDRESS=${{ vars.CI_TESTNET_STAGE_OWNER_ADDRESS }}" >> $GITHUB_ENV
             echo "PRIVATE_KEY=${{ secrets.CI_TESTNET_DEPLOYER_PRIVATE_KEY }}" >> $GITHUB_ENV
             echo "NETWORK=https://rpc.alephzero-testnet.gelato.digital" >> $GITHUB_ENV
-            echo "EXPLORER_URL=https://evm-explorer-testnet.alephzero.org/api" >> $GITHUB_ENV
+            echo "BLOCKSCOUT_URL=https://evm-explorer-testnet.alephzero.org/api" >> $GITHUB_ENV
           elif [ "${{ github.event.inputs.environment }}" == "prod" ]; then
             echo "OWNER_ADDRESS=${{ vars.MAINNET_PROD_OWNER_ADDRESS }}" >> $GITHUB_ENV
             echo "PRIVATE_KEY=${{ secrets.CI_MAINNET_DEPLOYER_PRIVATE_KEY }}" >> $GITHUB_ENV
             echo "NETWORK=https://rpc.alephzero.raas.gelato.cloud" >> $GITHUB_ENV
-            echo "EXPLORER_URL=https://evm-explorer.alephzero.org/api" >> $GITHUB_ENV
+            echo "BLOCKSCOUT_URL=https://evm-explorer.alephzero.org/api" >> $GITHUB_ENV
           else
             echo "Invalid environment selected!" >&2
             exit 1

--- a/crates/ar-cli/src/inspect.rs
+++ b/crates/ar-cli/src/inspect.rs
@@ -1,5 +1,6 @@
 use bip39::{Language, Mnemonic};
 use rpassword::read_password;
+use type_conversions::field_to_u256;
 
 use crate::{
     common::{deserialize_pub_key, mnemonic_to_seed, seed_to_keypair, serialize_pub_key},
@@ -19,12 +20,15 @@ pub fn run_mnemonic() -> Result<(), Error> {
 }
 
 pub fn run_pubkey(pk: &[u8; 64]) -> Result<(), Error> {
-    let _deserialized = deserialize_pub_key(pk)?;
+    let deserialized = deserialize_pub_key(pk)?;
     let (x, y) = pk.split_at(32);
     let x = x.to_vec();
     let y = y.to_vec();
     assert!(x.len() == 32 && y.len() == 32);
     println!("Public key is valid.");
     println!("AR_PUBLIC_KEY=\"{},{}\"", hex::encode(x), hex::encode(y));
+    let x_decimal = field_to_u256(deserialized.x);
+    let y_decimal = field_to_u256(deserialized.y);
+    println!("Decimal coordinates: {} {}", x_decimal, y_decimal);
     Ok(())
 }

--- a/scripts/verify-shielder.sh
+++ b/scripts/verify-shielder.sh
@@ -12,14 +12,10 @@ LIBRARIES=$(cat "$RUN_LATEST_PATH" | jq -r '.libraries | map("--libraries " + .)
 echo "Libraries $LIBRARIES"
 
 
-jq -c '.transactions[] | select(.transactionType == "CREATE" or .transactionType == "CREATE2")' "$RUN_LATEST_PATH" |
+jq -c '.transactions[] | select(.transactionType == "CREATE")' "$RUN_LATEST_PATH" |
 while read -r tx; do
   CONTRACT_NAME=$(echo "$tx" | jq -r '.contractName')
   CONTRACT_ADDRESS=$(echo "$tx" | jq -r '.contractAddress')
-    CONSTRUCTOR_ARGS=$(echo "$tx" | jq -r '.arguments | @sh' | xargs echo) # already ABI-encoded
-    if [[ -z "$CONSTRUCTOR_ARGS" || "$CONSTRUCTOR_ARGS" == "null" ]]; then
-        CONSTRUCTOR_ARGS="0x"
-    fi
   
 
   if [[ -z "$CONTRACT_NAME" || -z "$CONTRACT_ADDRESS" ]]; then
@@ -27,7 +23,7 @@ while read -r tx; do
     continue
   fi
 
-  echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDRESS using blockscout and constructor args $CONSTRUCTOR_ARGS"
+  echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDRESS using blockscout"
 
   forge verify-contract \
      --rpc-url ${NETWORK} --watch \
@@ -38,7 +34,7 @@ while read -r tx; do
     --guess-constructor-args
 
   if [[ -n "${ETHERSCAN_API_KEY:-}" ]]; then
-    echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDRESS using etherscan and constructor args $CONSTRUCTOR_ARGS"
+    echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDRESS using etherscan"
     forge verify-contract \
         --rpc-url ${NETWORK} --watch \
         --skip-is-verified-check \

--- a/scripts/verify-shielder.sh
+++ b/scripts/verify-shielder.sh
@@ -37,7 +37,7 @@ while read -r tx; do
     "$CONTRACT_ADDRESS" \
     --guess-constructor-args
 
-  if [[ -n "$ETHERSCAN_API_KEY" ]]; then
+  if [[ -n "${ETHERSCAN_API_KEY:-}" ]]; then
     echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDRESS using etherscan and constructor args $CONSTRUCTOR_ARGS"
     forge verify-contract \
         --rpc-url ${NETWORK} --watch \
@@ -67,7 +67,7 @@ while IFS=":" read -r SOURCE_FILE CONTRACT_NAME CONTRACT_ADDRESS; do
     "$CONTRACT_ADDRESS" \
     --constructor-args "0x"
 
-  if [[ -n "$ETHERSCAN_API_KEY" ]]; then
+  if [[ -n "${ETHERSCAN_API_KEY:-}" ]]; then
     echo "Verifying library $CONTRACT_NAME at $CONTRACT_ADDRESS on etherscan"
     forge verify-contract \
         --rpc-url ${NETWORK} --watch \


### PR DESCRIPTION
Rewrite verification script to support etherscan. The previous version didn't quite verify libraries on Etherscan so I rewrote slightly. This is very hard to test, because explorers cache verified contracts and behave differently when similar contract already exists.