### PR TITLE
ZK-834: Don't restrict token address casing

### DIFF
--- a/ts/shielder-sdk-tests/tests/shielder/singleuser.test.ts
+++ b/ts/shielder-sdk-tests/tests/shielder/singleuser.test.ts
@@ -13,6 +13,10 @@ import {
 
 const ercToken = erc20Token(tokenContractAddresses[0] as `0x${string}`);
 
+const ercTokenLowercase = erc20Token(
+  ercToken.address.toLowerCase() as `0x${string}`
+);
+
 [
   {
     id: 1,
@@ -25,7 +29,7 @@ const ercToken = erc20Token(tokenContractAddresses[0] as `0x${string}`);
 
       // create ERC20 account, deposit, withdraw manually and via relayer
       { op: shieldOp(ercToken, 10n ** 17n), actor: "alice" },
-      { op: shieldOp(ercToken, 2n * 10n ** 17n), actor: "alice" },
+      { op: shieldOp(ercTokenLowercase, 2n * 10n ** 17n), actor: "alice" },
       { op: withdrawManualOp(ercToken, 5n ** 17n, "bob"), actor: "alice" },
       {
         op: withdrawOp(ercToken, 7n ** 17n, "bob", 10n ** 17n),

--- a/ts/shielder-sdk-tests/web/fixtures/balanceRecorder.ts
+++ b/ts/shielder-sdk-tests/web/fixtures/balanceRecorder.ts
@@ -9,7 +9,10 @@ export const setupBalanceRecorder = (): BalanceRecorderFixture => {
   const tokenBalances = new Map<"native" | `0x${string}`, bigint>();
 
   const add = (token: Token, amount: bigint) => {
-    const key = token.type === "native" ? "native" : token.address;
+    const key =
+      token.type === "native"
+        ? "native"
+        : (token.address.toLowerCase() as `0x${string}`);
     const balance = tokenBalances.get(key) ?? 0n;
     tokenBalances.set(key, balance + amount);
   };
@@ -17,7 +20,10 @@ export const setupBalanceRecorder = (): BalanceRecorderFixture => {
   return {
     add,
     recordedBalance: (token: Token) => {
-      const key = token.type === "native" ? "native" : token.address;
+      const key =
+        token.type === "native"
+          ? "native"
+          : (token.address.toLowerCase() as `0x${string}`);
       return tokenBalances.get(key) ?? 0n;
     }
   };

--- a/ts/shielder-sdk-tests/web/fixtures/registrar.ts
+++ b/ts/shielder-sdk-tests/web/fixtures/registrar.ts
@@ -24,7 +24,10 @@ export const setupRegistrar = (): RegistrarFixture => {
   const registerShield = (token: Token, amount: bigint) => {
     balanceRecorder.add(token, amount);
 
-    const key = token.type === "native" ? "native" : token.address;
+    const key =
+      token.type === "native"
+        ? "native"
+        : (token.address.toLowerCase() as `0x${string}`);
     if (!tokenTxHistory.has(key)) {
       tokenTxHistory.set(key, []);
     }
@@ -48,7 +51,10 @@ export const setupRegistrar = (): RegistrarFixture => {
   ) => {
     balanceRecorder.add(token, -amount);
 
-    const key = token.type === "native" ? "native" : token.address;
+    const key =
+      token.type === "native"
+        ? "native"
+        : (token.address.toLowerCase() as `0x${string}`);
     if (!tokenTxHistory.has(key)) {
       tokenTxHistory.set(key, []);
     }
@@ -68,7 +74,10 @@ export const setupRegistrar = (): RegistrarFixture => {
       return balanceRecorder.recordedBalance(token);
     },
     recordedTxHistory: (token: Token) => {
-      const key = token.type === "native" ? "native" : token.address;
+      const key =
+        token.type === "native"
+          ? "native"
+          : (token.address.toLowerCase() as `0x${string}`);
       return tokenTxHistory.get(key) ?? [];
     }
   };

--- a/ts/shielder-sdk-tests/web/testUtils.ts
+++ b/ts/shielder-sdk-tests/web/testUtils.ts
@@ -16,7 +16,9 @@ export function envThreadsNumber(): number {
 }
 
 export function tokenToKey(token: Token) {
-  return token.type === "native" ? "native" : token.address;
+  return token.type === "native"
+    ? "native"
+    : (token.address.toLowerCase() as `0x${string}`);
 }
 
 export function keyToToken(key: "native" | `0x${string}`): Token {

--- a/ts/shielder-sdk/package.json
+++ b/ts/shielder-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardinal-cryptography/shielder-sdk",
-  "version": "0.2.0-beta.8",
+  "version": "0.2.0-beta.9",
   "description": "A web package for interacting with Shielder, a part of zkOS privacy engine.",
   "license": "Apache-2.0",
   "keywords": [

--- a/ts/shielder-sdk/src/state/sync/chainStateTransition.ts
+++ b/ts/shielder-sdk/src/state/sync/chainStateTransition.ts
@@ -55,7 +55,7 @@ export class ChainStateTransition {
           `Unexpected version in event: ${event.contractVersion}`
         );
       }
-      if (event.tokenAddress != tokenAddress) {
+      if (event.tokenAddress.toLowerCase() != tokenAddress.toLowerCase()) {
         throw new Error(
           `Unexpected token address in event: ${event.tokenAddress}`
         );

--- a/ts/shielder-sdk/src/storage/storageManager.ts
+++ b/ts/shielder-sdk/src/storage/storageManager.ts
@@ -48,7 +48,7 @@ export class StorageManager {
     const storageData = await this.storage.getStorage();
 
     for (const [index, account] of storageData.accounts.entries()) {
-      if (account.tokenAddress === tokenAddress) {
+      if (account.tokenAddress.toLowerCase() === tokenAddress.toLowerCase()) {
         return {
           accountIndex: parseInt(index),
           accountObject: { ...account }


### PR DESCRIPTION


This PR fixes an issue in the shielder-sdk where token addresses with different casing were incorrectly treated as distinct tokens.

### Problem

Previously, if a user referenced a token using an address with different casing than the one stored (e.g.
`requested_token = 0x1c66d6187b318f10eb1a8bd986451df02be3dbac` vs.
`stored_token = 0x1C66D6187B318f10Eb1A8BD986451DF02BE3DbAC`),
the SDK would treat them as separate tokens, leading to inconsistencies such as multiple local accounts being created for the same on-chain entity.

### Fix

Token addresses are now compared in their lower-cased form, making comparison case-insensitive.

