### PR TITLE
Report price age and expiration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5097,6 +5097,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "openssl",
  "parameterized",
+ "parking_lot",
  "rand",
  "reqwest",
  "rust_decimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ metrics-exporter-prometheus = { version = "0.16.0", default-features = false }
 num-bigint = { version = "0.4.3" }
 openssl = { version = "0.10.59" }
 parameterized = { version = "2.0.0" }
+parking_lot = { version = "0.12.3" }
 rand = { version = "0.8.5" }
 rayon = { version = "1.8" }
 reqwest = { version = "0.12.5" }

--- a/crates/shielder-relayer/Cargo.toml
+++ b/crates/shielder-relayer/Cargo.toml
@@ -25,6 +25,7 @@ clap = { workspace = true, features = ["derive"] }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 openssl = { workspace = true, features = ["vendored"] }
+parking_lot = { workspace = true }
 reqwest.workspace = true
 rust_decimal = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/shielder-relayer/Makefile
+++ b/crates/shielder-relayer/Makefile
@@ -61,5 +61,5 @@ start-dummy: build-image stop
 	FEE_DESTINATION_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" \
     RELAYER_SIGNING_KEYS="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d" \
     SHIELDER_CONTRACT_ADDRESS="0x1111111111111111111111111111111111111111" \
-    TOKEN_CONFIG="[{\"kind\":\"Native\", \"price_provider\":{\"Static\": 1}}]" \
+    TOKEN_CONFIG="[{\"kind\":\"Native\", \"price_provider\":{\"Static\": 1}}, {\"kind\":{\"ERC20\":{\"address\": \"0x6b175474e89094c44da98b954eedeac495271d0f\", \"decimals\": 6}}, \"price_provider\":{\"Url\": \"http://dupa.dupa\"}}, {\"kind\":{\"ERC20\":{\"address\": \"0xa0Ee7A142d267C1f36714E4a8F75612F20a79720\", \"decimals\": 6}}, \"price_provider\":{\"Url\": \"https://api.diadata.org/v1/assetQuotation/Ethereum/0x0000000000000000000000000000000000000000\"}}]" \
 	./run-relayer.sh

--- a/crates/shielder-relayer/Makefile
+++ b/crates/shielder-relayer/Makefile
@@ -61,5 +61,5 @@ start-dummy: build-image stop
 	FEE_DESTINATION_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" \
     RELAYER_SIGNING_KEYS="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d" \
     SHIELDER_CONTRACT_ADDRESS="0x1111111111111111111111111111111111111111" \
-    TOKEN_CONFIG="[{\"kind\":\"Native\", \"price_provider\":{\"Static\": 1}}, {\"kind\":{\"ERC20\":{\"address\": \"0x6b175474e89094c44da98b954eedeac495271d0f\", \"decimals\": 6}}, \"price_provider\":{\"Url\": \"http://dupa.dupa\"}}, {\"kind\":{\"ERC20\":{\"address\": \"0xa0Ee7A142d267C1f36714E4a8F75612F20a79720\", \"decimals\": 6}}, \"price_provider\":{\"Url\": \"https://api.diadata.org/v1/assetQuotation/Ethereum/0x0000000000000000000000000000000000000000\"}}]" \
+    TOKEN_CONFIG="[{\"kind\":\"Native\", \"price_provider\":{\"Static\": 1}}]" \
 	./run-relayer.sh

--- a/crates/shielder-relayer/src/metrics.rs
+++ b/crates/shielder-relayer/src/metrics.rs
@@ -26,6 +26,7 @@ pub const HEALTH: &str = "health";
 pub const SIGNER_BALANCES: &str = "signer_balances";
 pub const FEE_DESTINATION_BALANCE: &str = "fee_destination_balance";
 pub const EXPIRED_PRICE: &str = "expired_price";
+pub const PRICE_AGE: &str = "price_age";
 
 pub async fn prometheus_endpoint(
     metrics_handle: PrometheusHandle,
@@ -131,4 +132,13 @@ fn render_expired_prices(prices: &Prices) {
     }
 }
 
-fn render_price_ages(_prices: &Prices) {}
+fn render_price_ages(prices: &Prices) {
+    let ages = prices.price_ages();
+    for (token, age) in ages.iter() {
+        let age = match age {
+            Some(age) => age.as_seconds_f64(),
+            None => f64::MAX,
+        };
+        metrics::gauge!(PRICE_AGE, "token" => token.to_string()).set(age);
+    }
+}

--- a/crates/shielder-relayer/src/price_feed/mod.rs
+++ b/crates/shielder-relayer/src/price_feed/mod.rs
@@ -122,8 +122,8 @@ impl Prices {
 /// Start a price feed that updates the prices in the given `Prices` instance.
 pub async fn start_price_feed(prices: Prices) -> Result<(), anyhow::Error> {
     loop {
-        tokio::time::sleep(prices.refresh_interval).await;
         prices.update().await;
+        tokio::time::sleep(prices.refresh_interval).await;
     }
 }
 

--- a/crates/shielder-relayer/src/price_feed/mod.rs
+++ b/crates/shielder-relayer/src/price_feed/mod.rs
@@ -1,9 +1,7 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+use std::{collections::HashMap, sync::Arc};
 
 use fetching::fetch_price;
+use parking_lot::Mutex;
 pub use price::Price;
 #[cfg(test)]
 use rust_decimal::Decimal;
@@ -69,7 +67,7 @@ impl Prices {
         self.inner
             .iter()
             .map(|(token, price)| {
-                let price = price.lock().expect("Mutex poisoned");
+                let price = price.lock();
                 if price.is_none() {
                     // if the price is None, it means it was never fetched
                     return (*token, None);
@@ -88,7 +86,6 @@ impl Prices {
         self.inner
             .get(&token)?
             .lock()
-            .expect("Mutex poisoned")
             .clone()?
             .validate(&OffsetDateTime::now_utc())
     }
@@ -109,12 +106,7 @@ impl Prices {
             let price =
                 Price::from_price_info(price_info.unwrap(), token.decimals(), self.validity);
 
-            self.inner
-                .get(&token.kind)
-                .unwrap()
-                .lock()
-                .expect("Mutex poisoned")
-                .replace(price);
+            self.inner.get(&token.kind).unwrap().lock().replace(price);
         }
     }
 }

--- a/crates/shielder-relayer/src/price_feed/mod.rs
+++ b/crates/shielder-relayer/src/price_feed/mod.rs
@@ -57,6 +57,11 @@ impl Prices {
         }
     }
 
+    /// Gather current price for all the tokens.
+    pub fn current_prices(&self) -> Vec<(TokenKind, Option<Price>)> {
+        self.tokens.keys().map(|k| (*k, self.price(*k))).collect()
+    }
+
     /// Get the price of a token or `None` if the price is not available or outdated.
     pub fn price(&self, token: TokenKind) -> Option<Price> {
         self.inner

--- a/crates/shielder-relayer/src/token.rs
+++ b/crates/shielder-relayer/src/token.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use alloy_primitives::Address;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -21,6 +23,16 @@ impl From<TokenKind> for Token {
             TokenKind::Native => Token::Native,
             TokenKind::ERC20 { address, .. } => Token::ERC20(address),
         }
+    }
+}
+
+impl Display for TokenKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
+            TokenKind::Native => "native".to_string(),
+            TokenKind::ERC20 { address, .. } => format!("erc20:{address}"),
+        };
+        write!(f, "{str}")
     }
 }
 


### PR DESCRIPTION
1. Fix bug from the #228 - we shouldn't break the loop over all tokens if connecting to a price provider for one token failed. Now, we just `continue`
2. Expose `expired_price` metric - for all supported tokens, we indicate whether the price is outdated.
3. Expose `price_age` metric - for all supported tokens, display its price age in seconds. For static prices it is 0, for unavailable price it is `f64::MAX`.

Below is a screenshot for a relayer with 3 tokens:
 - native with static price
 - erc20 with real price feed url
 - erc20 with invalid feed url

![image](https://github.com/user-attachments/assets/a4fc8f9b-7673-4839-b466-2e1b1fd6b31c)
