### PR TITLE
Fix fix for the relayer workflow

### DIFF
--- a/.github/actions/shielder-relayer/deploy/action.yml
+++ b/.github/actions/shielder-relayer/deploy/action.yml
@@ -51,7 +51,7 @@ runs:
       shell: bash
       run: |
         cd aleph-apps/shielder-relayer-v2
-        yq -iy '.relayer.image.tag = "${{ inputs.image-tag }}"' dev-values.yaml
+        yq -i '.relayer.image.tag = "${{ inputs.image-tag }}"' dev-values.yaml
 
     - name: Update docker image tag (stage)
       if: ${{ inputs.environment == 'stage' || inputs.environment == 'all' }}

--- a/.github/actions/shielder-relayer/deploy/action.yml
+++ b/.github/actions/shielder-relayer/deploy/action.yml
@@ -58,14 +58,14 @@ runs:
       shell: bash
       run: |
         cd aleph-apps/shielder-relayer-v2
-        yq -iy '.relayer.image.tag = "${{ inputs.image-tag }}"' stage-values.yaml
+        yq -i '.relayer.image.tag = "${{ inputs.image-tag }}"' stage-values.yaml
 
     - name: Update docker image tag (prod)
       if: ${{ inputs.environment == 'prod' || inputs.environment == 'all' }}
       shell: bash
       run: |
         cd aleph-apps/shielder-relayer-v2
-        yq -iy '.relayer.image.tag = "${{ inputs.image-tag }}"' prod-values.yaml
+        yq -i '.relayer.image.tag = "${{ inputs.image-tag }}"' prod-values.yaml
 
     - name: GIT | Commit changes to aleph-apps repository
       uses: EndBug/add-and-commit@v9.1.4

--- a/.github/workflows/build-and-deploy-shielder-relayer.yml
+++ b/.github/workflows/build-and-deploy-shielder-relayer.yml
@@ -50,7 +50,7 @@ jobs:
         uses: ./.github/actions/shielder-relayer/deploy
         id: deploy_shielder_relayer
         with:
-          environment: prod
+          environment: ${{ github.event.inputs.environment }}
           image-tag: ${{ needs.build-and-push.outputs.image_tag }}
           autocommit-author: ${{ secrets.AUTOCOMMIT_AUTHOR }}
           autocommit-email: ${{ secrets.AUTOCOMMIT_EMAIL }}

--- a/.github/workflows/build-and-deploy-shielder-relayer.yml
+++ b/.github/workflows/build-and-deploy-shielder-relayer.yml
@@ -13,11 +13,6 @@ on:
           - stage
           - prod
         required: true
-      branch:
-        description: "Branch to check out (by default: main)"
-        type: string
-        default: main
-        required: true
 
 jobs:
   build-and-push:
@@ -26,8 +21,6 @@ jobs:
     steps:
       - name: GIT | Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch }}
 
       - name: Prepare Rust env
         uses: ./.github/actions/prepare-rust-env
@@ -52,8 +45,6 @@ jobs:
     steps:
       - name: GIT | Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch }}
 
       - name: Deploy
         uses: ./.github/actions/shielder-relayer/deploy


### PR DESCRIPTION
1. newest version of yq doesn't need `-y` flag
2. GH already has `branch` argument (must have added in recent months)
3. fix argument passing

successful run:
- https://github.com/Cardinal-Cryptography/zkOS-monorepo/actions/runs/15047952567
- https://github.com/Cardinal-Cryptography/aleph-apps/commit/68ab54dc0bffc6836a77a5a339423a9637c0bf88