### PR TITLE
Bring stress testing back to operational

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5301,6 +5301,7 @@ dependencies = [
  "alloy-signer-local",
  "anyhow",
  "clap",
+ "powers-of-tau",
  "rand",
  "reqwest",
  "shielder-account",

--- a/crates/stress-testing/Cargo.toml
+++ b/crates/stress-testing/Cargo.toml
@@ -16,6 +16,7 @@ alloy-rpc-types = { workspace = true }
 alloy-signer-local = { workspace = true }
 anyhow = { workspace = true, default-features = true }
 clap = { workspace = true, features = ["derive"] }
+powers-of-tau = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/stress-testing/local-scenario.sh
+++ b/crates/stress-testing/local-scenario.sh
@@ -12,9 +12,13 @@ run() {
   pushd $ROOT_DIR &>> output.log
 
   start_node
-  deploy_contracts
-  start_relayer
+
+  deploy_shielder_contracts
+  deploy_erc20_tokens
+  mint_erc20_tokens
+
   endow_accounts # only needed for relayer
+  start_relayer
 
   ${ROOT_DIR}/target/release/stress-testing \
     --master-seed "${DEPLOYER_PRIVATE_KEY}" \

--- a/crates/stress-testing/local-scenario.sh
+++ b/crates/stress-testing/local-scenario.sh
@@ -24,7 +24,7 @@ run() {
     --master-seed "${DEPLOYER_PRIVATE_KEY}" \
     --node-rpc-url "${NODE_RPC_URL}" \
     --shielder "${SHIELDER_CONTRACT_ADDRESS}" \
-    --relayer-url "${RELAYER_URL}/relay" \
+    --relayer-url "${RELAYER_URL}" \
     --relayer-address "${FEE_DESTINATION}" \
     --actor-count 10
 

--- a/crates/stress-testing/src/actor.rs
+++ b/crates/stress-testing/src/actor.rs
@@ -21,9 +21,14 @@ pub struct Actor {
     pub account: ShielderAccount,
 }
 
-const ANONYMITY_REVOKER_PKEY: GrumpkinPointAffine<U256> = GrumpkinPointAffine {
-    x: U256::from_limbs([65, 78, 79, 78]), // ANON
-    y: U256::from_limbs([89, 77, 73, 84]), // YMIT
+pub const ANONYMITY_REVOKER_PKEY: GrumpkinPointAffine<U256> = GrumpkinPointAffine {
+    x: U256::from_limbs([1, 0, 0, 0]),
+    y: U256::from_limbs([
+        9457493854555940652,
+        3253583849847263892,
+        14921373847124204899,
+        2,
+    ]),
 };
 
 impl Actor {

--- a/crates/stress-testing/src/actor.rs
+++ b/crates/stress-testing/src/actor.rs
@@ -1,5 +1,5 @@
 use alloy_signer_local::PrivateKeySigner;
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use shielder_account::{
     call_data::{NewAccountCallExtra, NewAccountCallType},
     ShielderAccount, Token,
@@ -33,10 +33,14 @@ pub const ANONYMITY_REVOKER_PKEY: GrumpkinPointAffine<U256> = GrumpkinPointAffin
 
 impl Actor {
     pub fn new(id: u32, rpc_url: String, shielder: Address) -> Self {
-        let signer = PrivateKeySigner::random_with(&mut StdRng::from_seed(seed(id)));
+        let mut rng = StdRng::from_seed(seed(id));
+
+        let signer = PrivateKeySigner::random_with(&mut rng);
         let shielder_user =
             ShielderUser::new(shielder, ConnectionPolicy::OnDemand { rpc_url, signer });
-        let account = ShielderAccount::new(U256::from(id), Token::Native);
+
+        let account = ShielderAccount::new(U256::from(rng.gen::<u64>()), Token::Native);
+
         Self {
             id,
             shielder_user,

--- a/crates/stress-testing/src/party.rs
+++ b/crates/stress-testing/src/party.rs
@@ -14,7 +14,7 @@ use shielder_contract::{
     alloy_primitives::U256, merkle_path::get_current_merkle_path,
     providers::create_simple_provider, ShielderContract::withdrawNativeCall,
 };
-use shielder_relayer::{QuoteFeeQuery, QuoteFeeResponse, RelayCalldata, RelayQuery};
+use shielder_relayer::{QuoteFeeQuery, QuoteFeeResponse, RelayCalldata, RelayQuery, RelayQuote};
 use shielder_setup::version::contract_version;
 
 use crate::{actor::Actor, config::Config, util::proving_keys, WITHDRAW_AMOUNT};
@@ -80,7 +80,7 @@ async fn prepare_relay_queries(
     let (params, pk) = proving_keys::<WithdrawCircuit>();
     let mut result = Vec::new();
 
-    let total_fee = reqwest::Client::new()
+    let quote = reqwest::Client::new()
         .post(config.relayer_url.clone() + "/quote_fees")
         .json(&QuoteFeeQuery {
             fee_token: Token::Native,
@@ -89,13 +89,11 @@ async fn prepare_relay_queries(
         .send()
         .await?
         .json::<QuoteFeeResponse>()
-        .await?
-        .fee_details
-        .total_cost_fee_token;
+        .await?;
 
     println!("⏳ Preparing relay queries for actors...");
     for actor in actors {
-        let query = prepare_relay_query(config, &actor, &params, &pk, total_fee).await?;
+        let query = prepare_relay_query(config, &actor, &params, &pk, quote.clone()).await?;
         result.push((actor, query));
     }
     Ok(result)
@@ -106,7 +104,7 @@ async fn prepare_relay_query(
     actor: &Actor,
     params: &Params,
     pk: &ProvingKey,
-    relayer_fee: U256,
+    quote: QuoteFeeResponse,
 ) -> Result<RelayQuery> {
     let (merkle_root, merkle_path) =
         get_current_merkle_path(U256::from(actor.id), &actor.shielder_user).await?;
@@ -115,6 +113,7 @@ async fn prepare_relay_query(
         .await?
         .get_chain_id()
         .await?;
+    let amount = U256::from(WITHDRAW_AMOUNT) + quote.fee_details.total_cost_native;
 
     let calldata: withdrawNativeCall = actor
         .account
@@ -122,12 +121,12 @@ async fn prepare_relay_query(
             params,
             pk,
             Token::Native,
-            U256::from(WITHDRAW_AMOUNT),
+            amount,
             &WithdrawExtra {
                 merkle_path,
                 to,
                 relayer_address: config.relayer_address,
-                relayer_fee,
+                relayer_fee: quote.fee_details.total_cost_fee_token,
                 contract_version: contract_version(),
                 chain_id: U256::from(chain_id),
                 mac_salt: U256::ZERO,
@@ -140,7 +139,7 @@ async fn prepare_relay_query(
     let query = RelayQuery {
         calldata: RelayCalldata {
             expected_contract_version: contract_version().to_bytes(),
-            amount: U256::from(WITHDRAW_AMOUNT),
+            amount,
             withdraw_address: to,
             merkle_root,
             nullifier_hash: calldata.oldNullifierHash,
@@ -152,7 +151,11 @@ async fn prepare_relay_query(
             mac_commitment: calldata.macCommitment,
             pocket_money: U256::ZERO,
         },
-        quote: Default::default(),
+        quote: RelayQuote {
+            gas_price: quote.price_details.gas_price,
+            native_token_unit_price: quote.price_details.native_token_unit_price,
+            fee_token_unit_price: quote.price_details.fee_token_unit_price,
+        },
     };
     println!("  ✅ Prepared relay query for actor {}", actor.id);
     Ok(query)

--- a/crates/stress-testing/src/party.rs
+++ b/crates/stress-testing/src/party.rs
@@ -14,7 +14,7 @@ use shielder_contract::{
     alloy_primitives::U256, merkle_path::get_current_merkle_path,
     providers::create_simple_provider, ShielderContract::withdrawNativeCall,
 };
-use shielder_relayer::{QuoteFeeResponse, RelayCalldata, RelayQuery};
+use shielder_relayer::{QuoteFeeQuery, QuoteFeeResponse, RelayCalldata, RelayQuery};
 use shielder_setup::version::contract_version;
 
 use crate::{actor::Actor, config::Config, util::proving_keys, WITHDRAW_AMOUNT};
@@ -81,7 +81,11 @@ async fn prepare_relay_queries(
     let mut result = Vec::new();
 
     let total_fee = reqwest::Client::new()
-        .get(config.relayer_url.clone() + "/quote_fee")
+        .post(config.relayer_url.clone() + "/quote_fees")
+        .json(&QuoteFeeQuery {
+            fee_token: Token::Native,
+            pocket_money: U256::ZERO,
+        })
         .send()
         .await?
         .json::<QuoteFeeResponse>()

--- a/crates/stress-testing/src/util.rs
+++ b/crates/stress-testing/src/util.rs
@@ -1,11 +1,15 @@
+use powers_of_tau::{get_ptau_file_path, read as read_setup_parameters, Format};
 use shielder_circuits::{
     circuits::{Params, ProvingKey},
-    generate_keys_with_min_k, generate_setup_params, Circuit, Fr, MAX_K,
+    generate_keys_with_min_k, Circuit, Fr, MAX_K,
 };
-use shielder_setup::parameter_generation;
 
 pub fn proving_keys<C: Circuit<Fr> + Default>() -> (Params, ProvingKey) {
-    let params = generate_setup_params(MAX_K, &mut parameter_generation::rng());
+    let params = read_setup_parameters(
+        get_ptau_file_path(MAX_K, Format::PerpetualPowersOfTau),
+        Format::PerpetualPowersOfTau,
+    )
+    .unwrap();
     let (params, _, pk, _) = generate_keys_with_min_k(C::default(), params).unwrap();
     (params, pk)
 }


### PR DESCRIPTION
1. Use true powers-of-tau (to be compatible with deployed contracts)
2. Fix setup script
3. Use correct AR key
4. Generate unique, correct ZK IDs (serial integers are not sufficient anymore)
5. Fix handling quotes