### PR TITLE
change Provider<Transport, Ethereum> to Provider<Transport, AnyNetwork>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5042,6 +5042,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-signer-local",
  "alloy-sol-types",
+ "alloy-transport",
  "anyhow",
  "clap",
  "content-encryption",

--- a/crates/shielder-cli/Cargo.toml
+++ b/crates/shielder-cli/Cargo.toml
@@ -16,6 +16,7 @@ alloy-provider = { workspace = true }
 alloy-rpc-types-eth = { workspace = true }
 alloy-signer-local = { workspace = true }
 alloy-sol-types = { workspace = true }
+alloy-transport = { workspace = true }
 anyhow = { workspace = true, default-features = true }
 clap = { workspace = true, features = ["derive"] }
 inquire = { workspace = true }
@@ -25,7 +26,11 @@ serde_json = { workspace = true }
 shellexpand = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }
+tracing-subscriber = { workspace = true, features = [
+    "fmt",
+    "json",
+    "env-filter",
+] }
 
 content-encryption = { workspace = true, features = ["std"] }
 powers-of-tau = { workspace = true }

--- a/crates/shielder-cli/src/app_state.rs
+++ b/crates/shielder-cli/src/app_state.rs
@@ -4,8 +4,9 @@ use std::{
 };
 
 use alloy_primitives::{Address, U256};
-use alloy_provider::Provider;
+use alloy_provider::{network::AnyNetwork, Provider};
 use alloy_signer_local::PrivateKeySigner;
+use alloy_transport::BoxTransport;
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use shielder_account::{ShielderAccount, Token};
@@ -126,7 +127,9 @@ Depositor signing key: {}",
         )
     }
 
-    pub async fn create_simple_provider(&self) -> Result<impl Provider, ShielderContractError> {
+    pub async fn create_simple_provider(
+        &self,
+    ) -> Result<impl Provider<BoxTransport, AnyNetwork>, ShielderContractError> {
         create_simple_provider(&self.node_rpc_url).await
     }
 }

--- a/crates/shielder-cli/src/shielder_ops/withdraw.rs
+++ b/crates/shielder-cli/src/shielder_ops/withdraw.rs
@@ -1,7 +1,8 @@
 use std::str::FromStr;
 
 use alloy_primitives::{Address, BlockHash, TxHash, U256};
-use alloy_provider::Provider;
+use alloy_provider::{network::AnyNetwork, Provider};
+use alloy_transport::BoxTransport;
 use anyhow::{anyhow, bail, Result};
 use serde::Serialize;
 use shielder_account::{
@@ -81,7 +82,10 @@ pub async fn withdraw(
     Ok(())
 }
 
-async fn get_block_hash(provider: &impl Provider, tx_hash: TxHash) -> Result<BlockHash> {
+async fn get_block_hash(
+    provider: &impl Provider<BoxTransport, AnyNetwork>,
+    tx_hash: TxHash,
+) -> Result<BlockHash> {
     for _ in 0..5 {
         if let Some(receipt) = provider.get_transaction_receipt(tx_hash).await? {
             if let Some(block_hash) = receipt.block_hash {

--- a/crates/shielder-contract/src/events.rs
+++ b/crates/shielder-contract/src/events.rs
@@ -1,13 +1,15 @@
+use alloy_network::AnyNetwork;
 use alloy_primitives::{BlockHash, TxHash};
 use alloy_provider::Provider;
 use alloy_rpc_types::Filter;
 use alloy_sol_types::SolEvent;
+use alloy_transport::BoxTransport;
 
 use crate::{ContractResult, ShielderContractError};
 
 /// Look at the logs of `tx_hash` in `block_hash` and return the first event of type `Event`.
 pub async fn get_event<Event: SolEvent>(
-    provider: &impl Provider,
+    provider: &impl Provider<BoxTransport, AnyNetwork>,
     tx_hash: TxHash,
     block_hash: BlockHash,
 ) -> ContractResult<Event> {

--- a/crates/shielder-contract/src/providers.rs
+++ b/crates/shielder-contract/src/providers.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use alloy_network::{Ethereum, EthereumWallet, Network};
+use alloy_network::{AnyNetwork, Ethereum, EthereumWallet, Network};
 use alloy_provider::{
     fillers::{
         BlobGasFiller, CachedNonceManager, ChainIdFiller, FillerControlFlow, GasFiller,
@@ -9,7 +9,7 @@ use alloy_provider::{
     Provider, ProviderBuilder, SendableTx,
 };
 use alloy_signer_local::PrivateKeySigner;
-use alloy_transport::{Transport, TransportResult};
+use alloy_transport::{BoxTransport, Transport, TransportResult};
 
 use crate::{ContractResult, ShielderContractError};
 
@@ -18,8 +18,11 @@ use crate::{ContractResult, ShielderContractError};
 /// This is a simple provider, without any fillers or
 /// signer configuration (apart from some devnet-specific defaults). It is suitable for doing
 /// read-only operations.
-pub async fn create_simple_provider(rpc_url: &str) -> ContractResult<impl Provider> {
+pub async fn create_simple_provider(
+    rpc_url: &str,
+) -> ContractResult<impl Provider<BoxTransport, AnyNetwork>> {
     ProviderBuilder::new()
+        .network::<AnyNetwork>()
         .on_builtin(rpc_url)
         .await
         .map_err(ShielderContractError::ProviderError)


### PR DESCRIPTION
account recovery in `shielder-cli` was not working for `aleph zero` and `arbitrum` network, as their block structure is not compatible with default `ethereum` parser. To fix that, I changed `Provider = Provider<BoxTransport, Ethereum>` trait to `Provider<BoxTransport, AnyNetwork>`.