### PR TITLE
BAC-170: Protocol fee

### DIFF
--- a/contracts/ProtocolFee.sol
+++ b/contracts/ProtocolFee.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.26;
+
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+
+using SafeERC20 for IERC20;
+using Math for uint256;
+
+abstract contract ProtocolFee is Initializable {
+    uint256 private constant MAX_BPS = 10000;
+    uint256 private constant MAX_FEE_BPS = 500;
+
+    // keccak256(abi.encode(uint256(keccak256("zkos.storage.ProtocolFee")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant PROTOCOL_FEE_LOCATION =
+        0x9c87721c17e6235fff8083d0b9984a29270f914f1ee4a52de715ea78a62a0b00;
+
+    /// @custom:storage-location erc7201:zkos.storage.ProtocolFee
+    struct ProtocolFeeStorage {
+        uint256 protocolDepositFeeBps;
+        uint256 protocolWithdrawFeeBps;
+        address protocolFeeReceiver;
+    }
+
+    error DepositFeeTooHigh();
+    error WithdrawFeeTooHigh();
+
+    function _getProtocolFeeStorage()
+        private
+        pure
+        returns (ProtocolFeeStorage storage $)
+    {
+        assembly {
+            $.slot := PROTOCOL_FEE_LOCATION
+        }
+    }
+
+    // solhint-disable func-name-mixedcase
+    function __ProtocolFee_init(
+        uint256 _depositFeeBps,
+        uint256 _withdrawFeeBps,
+        address _protocolFeeReceiver
+    ) internal onlyInitializing {
+        require(_depositFeeBps <= MAX_FEE_BPS, DepositFeeTooHigh());
+        require(_withdrawFeeBps <= MAX_FEE_BPS, WithdrawFeeTooHigh());
+
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        $.protocolDepositFeeBps = _depositFeeBps;
+        $.protocolWithdrawFeeBps = _withdrawFeeBps;
+        $.protocolFeeReceiver = _protocolFeeReceiver;
+    }
+
+    function protocolFeeReceiver() public view returns (address) {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        return $.protocolFeeReceiver;
+    }
+
+    function protocolWithdrawFeeBps() public view returns (uint256) {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        return $.protocolWithdrawFeeBps;
+    }
+
+    function protocolDepositFeeBps() public view returns (uint256) {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        return $.protocolDepositFeeBps;
+    }
+
+    function _computeProtocolDepositFeeFromNetAmount(
+        uint256 amount
+    ) internal view returns (uint256) {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        return
+            amount.mulDiv($.protocolDepositFeeBps, MAX_BPS, Math.Rounding.Ceil);
+    }
+
+    function _computeProtocolDepositFeeFromGrossAmount(
+        uint256 amount
+    ) internal view returns (uint256) {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        return
+            amount.mulDiv(
+                $.protocolDepositFeeBps,
+                MAX_BPS + $.protocolDepositFeeBps,
+                Math.Rounding.Ceil
+            );
+    }
+
+    function _computeProtocolWithdrawFee(
+        uint256 amount
+    ) internal view returns (uint256) {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        return
+            amount.mulDiv(
+                $.protocolWithdrawFeeBps,
+                MAX_BPS,
+                Math.Rounding.Ceil
+            );
+    }
+
+    function _setProtocolFeeReceiver(address newProtocolFeeReceiver) internal {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        $.protocolFeeReceiver = newProtocolFeeReceiver;
+    }
+
+    function _setProtocolDepositFeeBps(
+        uint256 newProtocolDepositFeeBps
+    ) internal {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        require(newProtocolDepositFeeBps <= MAX_FEE_BPS, DepositFeeTooHigh());
+        $.protocolDepositFeeBps = newProtocolDepositFeeBps;
+    }
+
+    function _setProtocolWithdrawFeeBps(
+        uint256 newProtocolWithdrawFeeBps
+    ) internal {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        require(newProtocolWithdrawFeeBps <= MAX_FEE_BPS, WithdrawFeeTooHigh());
+        $.protocolWithdrawFeeBps = newProtocolWithdrawFeeBps;
+    }
+}

--- a/contracts/Shielder.sol
+++ b/contracts/Shielder.sol
@@ -8,6 +8,7 @@ import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/I
 import { MerkleTree } from "./MerkleTree.sol";
 import { Nullifiers } from "./Nullifiers.sol";
 import { AnonymityRevoker } from "./AnonymityRevoker.sol";
+import { ProtocolFee } from "./ProtocolFee.sol";
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
@@ -26,7 +27,8 @@ contract Shielder is
     PausableUpgradeable,
     MerkleTree,
     Nullifiers,
-    AnonymityRevoker
+    AnonymityRevoker,
+    ProtocolFee
 {
     // -- Constants --
 
@@ -66,7 +68,8 @@ contract Shielder is
         uint256 newNote,
         uint256 newNoteIndex,
         uint256 macSalt,
-        uint256 macCommitment
+        uint256 macCommitment,
+        uint256 protocolFee
     );
     event Deposit(
         bytes3 contractVersion,
@@ -75,7 +78,8 @@ contract Shielder is
         uint256 newNote,
         uint256 newNoteIndex,
         uint256 macSalt,
-        uint256 macCommitment
+        uint256 macCommitment,
+        uint256 protocolFee
     );
     event Withdraw(
         bytes3 contractVersion,
@@ -88,7 +92,8 @@ contract Shielder is
         uint256 fee,
         uint256 macSalt,
         uint256 macCommitment,
-        uint256 pocketMoney
+        uint256 pocketMoney,
+        uint256 protocolFee
     );
 
     // -- Errors --
@@ -122,7 +127,10 @@ contract Shielder is
         address initialOwner,
         uint256 _anonymityRevokerPublicKeyX,
         uint256 _anonymityRevokerPublicKeyY,
-        bool _isArbitrumChain
+        bool _isArbitrumChain,
+        uint256 _protocolDepositFeeBps,
+        uint256 _protocolWithdrawFeeBps,
+        address _protocolFeeReceiver
     ) public initializer {
         __Ownable_init(initialOwner);
         __Pausable_init();
@@ -132,6 +140,11 @@ contract Shielder is
             _anonymityRevokerPublicKeyY
         );
         __Nullifiers_init(_isArbitrumChain);
+        __ProtocolFee_init(
+            _protocolDepositFeeBps,
+            _protocolWithdrawFeeBps,
+            _protocolFeeReceiver
+        );
         _pause();
     }
 
@@ -147,6 +160,24 @@ contract Shielder is
 
     function unpause() external onlyOwner {
         _unpause();
+    }
+
+    function setProtocolFeeReceiver(
+        address newProtocolFeeReceiver
+    ) external onlyOwner {
+        _setProtocolFeeReceiver(newProtocolFeeReceiver);
+    }
+
+    function setProtocolDepositFeeBps(
+        uint256 newProtocolDepositFeeBps
+    ) external onlyOwner {
+        _setProtocolDepositFeeBps(newProtocolDepositFeeBps);
+    }
+
+    function setProtocolWithdrawFeeBps(
+        uint256 newProtocolWithdrawFeeBps
+    ) external onlyOwner {
+        _setProtocolWithdrawFeeBps(newProtocolWithdrawFeeBps);
     }
 
     /*
@@ -179,11 +210,14 @@ contract Shielder is
         uint256 macCommitment,
         bytes calldata proof
     ) external payable whenNotPaused {
-        uint256 amount = msg.value;
         // `address(this).balance` already includes `msg.value`.
         if (address(this).balance > MAX_CONTRACT_BALANCE) {
             revert ContractBalanceLimitReached();
         }
+
+        uint256 amount = msg.value;
+        uint256 protocolFee = _computeProtocolDepositFeeFromGrossAmount(amount);
+        amount = amount - protocolFee;
 
         uint256 newNoteIndex = _newAccount(
             expectedContractVersion,
@@ -200,6 +234,13 @@ contract Shielder is
             proof
         );
 
+        // pay out the protocol fee
+        (bool nativeTransferSuccess, ) = protocolFeeReceiver().call{
+            value: protocolFee,
+            gas: GAS_LIMIT
+        }("");
+        if (!nativeTransferSuccess) revert NativeTransferFailed();
+
         emit NewAccount(
             CONTRACT_VERSION,
             prenullifier,
@@ -208,7 +249,8 @@ contract Shielder is
             newNote,
             newNoteIndex,
             macSalt,
-            macCommitment
+            macCommitment,
+            protocolFee
         );
     }
 
@@ -239,6 +281,8 @@ contract Shielder is
             revert ContractBalanceLimitReached();
         }
 
+        uint256 protocolFee = _computeProtocolDepositFeeFromNetAmount(amount);
+
         uint256 newNoteIndex = _newAccount(
             expectedContractVersion,
             tokenAddress,
@@ -255,6 +299,7 @@ contract Shielder is
         );
 
         token.safeTransferFrom(msg.sender, address(this), amount);
+        token.safeTransferFrom(msg.sender, protocolFeeReceiver(), protocolFee);
 
         emit NewAccount(
             CONTRACT_VERSION,
@@ -264,7 +309,8 @@ contract Shielder is
             newNote,
             newNoteIndex,
             macSalt,
-            macCommitment
+            macCommitment,
+            protocolFee
         );
     }
 
@@ -337,10 +383,13 @@ contract Shielder is
         uint256 macCommitment,
         bytes calldata proof
     ) external payable whenNotPaused {
-        uint256 amount = msg.value;
         if (address(this).balance > MAX_CONTRACT_BALANCE) {
             revert ContractBalanceLimitReached();
         }
+
+        uint256 amount = msg.value;
+        uint256 protocolFee = _computeProtocolDepositFeeFromGrossAmount(amount);
+        amount = amount - protocolFee;
 
         uint256 newNoteIndex = _deposit(
             expectedContractVersion,
@@ -354,6 +403,13 @@ contract Shielder is
             proof
         );
 
+        // pay out the protocol fee
+        (bool nativeTransferSuccess, ) = protocolFeeReceiver().call{
+            value: protocolFee,
+            gas: GAS_LIMIT
+        }("");
+        if (!nativeTransferSuccess) revert NativeTransferFailed();
+
         emit Deposit(
             CONTRACT_VERSION,
             NATIVE_TOKEN_NOTE_ADDRESS,
@@ -361,7 +417,8 @@ contract Shielder is
             newNote,
             newNoteIndex,
             macSalt,
-            macCommitment
+            macCommitment,
+            protocolFee
         );
     }
 
@@ -387,6 +444,8 @@ contract Shielder is
             revert ContractBalanceLimitReached();
         }
 
+        uint256 protocolFee = _computeProtocolDepositFeeFromNetAmount(amount);
+
         uint256 newNoteIndex = _deposit(
             expectedContractVersion,
             tokenAddress,
@@ -400,6 +459,7 @@ contract Shielder is
         );
 
         token.safeTransferFrom(msg.sender, address(this), amount);
+        token.safeTransferFrom(msg.sender, protocolFeeReceiver(), protocolFee);
 
         emit Deposit(
             CONTRACT_VERSION,
@@ -408,7 +468,8 @@ contract Shielder is
             newNote,
             newNoteIndex,
             macSalt,
-            macCommitment
+            macCommitment,
+            protocolFee
         );
     }
 
@@ -488,16 +549,29 @@ contract Shielder is
             0
         );
 
+        uint256 receiverAmount = amount - relayerFee;
+        uint256 receiverProtocolFee = _computeProtocolWithdrawFee(
+            receiverAmount
+        );
+        uint256 relayerProtocolFee = _computeProtocolWithdrawFee(relayerFee);
+
         // return the tokens
         (bool nativeTransferSuccess, ) = withdrawalAddress.call{
-            value: amount - relayerFee,
+            value: receiverAmount - receiverProtocolFee,
             gas: GAS_LIMIT
         }("");
         if (!nativeTransferSuccess) revert NativeTransferFailed();
 
-        // pay out the fee
+        // pay out the relayer fee
         (nativeTransferSuccess, ) = relayerAddress.call{
-            value: relayerFee,
+            value: relayerFee - relayerProtocolFee,
+            gas: GAS_LIMIT
+        }("");
+        if (!nativeTransferSuccess) revert NativeTransferFailed();
+
+        // pay out the protocol fee
+        (nativeTransferSuccess, ) = protocolFeeReceiver().call{
+            value: receiverProtocolFee + relayerProtocolFee,
             gas: GAS_LIMIT
         }("");
         if (!nativeTransferSuccess) revert NativeTransferFailed();
@@ -513,7 +587,8 @@ contract Shielder is
             relayerFee,
             macSalt,
             macCommitment,
-            0
+            0,
+            receiverProtocolFee
         );
     }
 
@@ -549,9 +624,22 @@ contract Shielder is
             pocketMoney
         );
 
+        uint256 receiverAmount = amount - relayerFee;
+        uint256 receiverProtocolFee = _computeProtocolWithdrawFee(
+            receiverAmount
+        );
+        uint256 relayerProtocolFee = _computeProtocolWithdrawFee(relayerFee);
+
         IERC20 token = IERC20(tokenAddress);
-        token.safeTransfer(withdrawalAddress, amount - relayerFee);
-        token.safeTransfer(relayerAddress, relayerFee);
+        token.safeTransfer(
+            withdrawalAddress,
+            receiverAmount - receiverProtocolFee
+        );
+        token.safeTransfer(relayerAddress, relayerFee - relayerProtocolFee);
+        token.safeTransfer(
+            protocolFeeReceiver(),
+            receiverProtocolFee + relayerProtocolFee
+        );
 
         // forward pocket money
         if (pocketMoney != 0) {
@@ -573,7 +661,8 @@ contract Shielder is
             relayerFee,
             macSalt,
             macCommitment,
-            pocketMoney
+            pocketMoney,
+            receiverProtocolFee
         );
     }
 

--- a/scripts/Shielder.s.sol
+++ b/scripts/Shielder.s.sol
@@ -19,6 +19,12 @@ contract DeployShielderScript is Script {
         uint256 arPublicKeyX = uint256(vm.envBytes32("AR_PUBLIC_KEY_X"));
         uint256 arPublicKeyY = uint256(vm.envBytes32("AR_PUBLIC_KEY_Y"));
 
+        uint256 protocolDepositFeeBps = vm.envUint("PROTOCOL_DEPOSIT_FEE_BPS");
+        uint256 protocolWithdrawFeeBps = vm.envUint(
+            "PROTOCOL_WITHDRAW_FEE_BPS"
+        );
+        address protocolFeeReceiver = vm.envAddress("PROTOCOL_FEE_RECEIVER");
+
         bool isArbitrumChain = vm.envBool("IS_ARBITRUM_CHAIN");
 
         vm.startBroadcast(privateKey);
@@ -32,7 +38,15 @@ contract DeployShielderScript is Script {
 
         bytes memory data = abi.encodeCall(
             Shielder.initialize,
-            (owner, arPublicKeyX, arPublicKeyY, isArbitrumChain)
+            (
+                owner,
+                arPublicKeyX,
+                arPublicKeyY,
+                isArbitrumChain,
+                protocolDepositFeeBps,
+                protocolWithdrawFeeBps,
+                protocolFeeReceiver
+            )
         );
 
         address proxy = address(new ERC1967Proxy(shielderImplementation, data));

--- a/test/ShielderUpgrade.t.sol
+++ b/test/ShielderUpgrade.t.sol
@@ -13,6 +13,9 @@ contract ShielderUpgrade is Test {
 
     uint256 public anonymityRevokerPubkeyX = 42;
     uint256 public anonymityRevokerPubkeyY = 43;
+    uint256 public protocolDepositFeeBps = 5;
+    uint256 public protocolWithdrawFeeBps = 5;
+    address public protocolFeeReceiver = owner;
 
     string[] public allowedErrors;
 
@@ -75,7 +78,15 @@ contract ShielderUpgrade is Test {
             "Shielder.sol:Shielder",
             abi.encodeCall(
                 Shielder.initialize,
-                (owner, anonymityRevokerPubkeyX, anonymityRevokerPubkeyY, false)
+                (
+                    owner,
+                    anonymityRevokerPubkeyX,
+                    anonymityRevokerPubkeyY,
+                    false,
+                    protocolDepositFeeBps,
+                    protocolWithdrawFeeBps,
+                    protocolFeeReceiver
+                )
             )
         );
         Shielder shielder = Shielder(shielderProxy);


### PR DESCRIPTION
Add protocol fee to the deposit and withdrawal actions.

`newAccount` / `deposit` protocol fee:
 - native
   - Applied over the `msg.value` amount inclusively (`msg.sender` = deposit + fee )
 - erc20
   - Applied over the `amount` specified in the args exclusively (`amount` = deposit). Shielder transfers from the user `amount` + fee. 
   
`withdraw` fee:
- native and erc20
  - Applied over the `msg.value`/`amount` inclusively. `relayerFee` must be greater than `amount - protocolFee`
  - Receiver gets `amount - protocolFee - relayerFee`
   
TODO: 
 - [ ] Bump Shielder version
 - [x] Add "memo" bytes to the `newAccount`, `deposit`  and `withdraw`
