### PR TITLE
BAC-181: Circuit configuration for shielder-prover-server

### DIFF
--- a/tee/Cargo.lock
+++ b/tee/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
 ]
@@ -48,6 +48,43 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "alloy-primitives"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c77490fe91a0ce933a1f219029521f20fc28c2c0ca95d53fa4da9c00b8d9d4e"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "foldhash",
+ "hashbrown 0.15.3",
+ "indexmap",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.8.5",
+ "ruint",
+ "rustc-hash",
+ "serde",
+ "sha3 0.10.8",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f70d83b765fdc080dbcd4f4db70d8d23fe4761f2f02ebfa9146b833900634b4"
+dependencies = [
+ "arrayvec",
+ "bytes",
+]
 
 [[package]]
 name = "android-tzdata"
@@ -115,6 +152,136 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +327,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -250,6 +428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +460,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +496,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2b_simd"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +524,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
@@ -333,6 +559,12 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytecheck"
@@ -367,6 +599,9 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -458,10 +693,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e22e0ed40b96a48d3db274f72fd365bd78f67af39b6bbd47e8a15e1c6207ff"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation-sys"
@@ -494,6 +768,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +802,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +827,41 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -540,12 +886,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -569,12 +956,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -607,6 +1027,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +1056,57 @@ dependencies = [
  "concurrent-queue",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "bitvec",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
+ "static_assertions",
 ]
 
 [[package]]
@@ -774,6 +1255,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -784,7 +1266,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -792,6 +1286,75 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "halo2_poseidon"
+version = "0.2.0"
+source = "git+https://github.com/Cardinal-Cryptography/poseidon-gadget?rev=ce317a6#ce317a65e0f1148ce9220a7f3281ef0f27544fb4"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "ff",
+ "group",
+ "halo2_proofs",
+ "halo2curves",
+ "hex",
+ "lazy_static",
+ "rand 0.8.5",
+ "subtle",
+ "uint",
+]
+
+[[package]]
+name = "halo2_proofs"
+version = "0.3.0"
+source = "git+https://github.com/privacy-scaling-explorations/halo2?tag=v0.3.0#73408a140737d8336490452193b21f5a7a94e7de"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "halo2curves",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "rayon",
+ "serde",
+ "serde_derive",
+ "sha3 0.9.1",
+ "tracing",
+]
+
+[[package]]
+name = "halo2curves"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db81d01d0bbfec9f624d7590fc6929ee2537a64ec1e080d8f8c9e2d2da291405"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "lazy_static",
+ "num-bigint",
+ "num-traits",
+ "pairing",
+ "pasta_curves",
+ "paste",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rayon",
+ "static_assertions",
+ "subtle",
+]
 
 [[package]]
 name = "hashbrown"
@@ -811,6 +1374,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -839,6 +1403,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hkdf"
@@ -855,7 +1422,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -912,6 +1479,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "human_bytes"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
 
 [[package]]
 name = "hyper"
@@ -1059,6 +1632,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1659,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,6 +1686,7 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.3",
+ "serde",
 ]
 
 [[package]]
@@ -1105,6 +1705,24 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1147,6 +1765,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1828,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1856,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "macros"
+version = "0.1.0"
+source = "git+https://github.com/Cardinal-Cryptography/zkOS-circuits?rev=df31437#df314375b3fc0dad87a0e2805ff3c616b1794f35"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,7 +1879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1252,7 +1919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -1291,7 +1958,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -1348,6 +2015,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,6 +2049,43 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
  "quote",
  "syn 2.0.101",
 ]
@@ -1410,6 +2120,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pasta_curves"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "lazy_static",
+ "rand 0.8.5",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,6 +2154,17 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
 
 [[package]]
 name = "pgvector"
@@ -1503,12 +2245,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "powers-of-tau"
+version = "0.1.0"
+dependencies = [
+ "byteorder",
+ "halo2_proofs",
+ "halo2curves",
+ "num-bigint",
+ "rand 0.8.5",
+ "shielder-circuits",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
 ]
 
 [[package]]
@@ -1565,6 +2330,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,6 +2370,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,6 +2383,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -1606,8 +2403,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1617,7 +2425,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1626,7 +2444,45 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1677,6 +2533,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,24 +2572,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
  "const-oid",
- "digest",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "ruint"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11256b5fe8c68f56ac6f39ef0720e592f33d2367a4782740d9c9142e889c7fb4"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand 0.8.5",
+ "rand 0.9.1",
+ "rlp",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rust_decimal"
@@ -1735,7 +2644,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -1748,10 +2657,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver 1.0.26",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1860,6 +2824,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,7 +2923,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1932,7 +2934,58 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
+dependencies = [
+ "cc",
+ "cfg-if",
+]
+
+[[package]]
+name = "shielder-circuits"
+version = "0.1.0"
+source = "git+https://github.com/Cardinal-Cryptography/zkOS-circuits?rev=df31437#df314375b3fc0dad87a0e2805ff3c616b1794f35"
+dependencies = [
+ "halo2_poseidon",
+ "halo2_proofs",
+ "human_bytes",
+ "lazy_static",
+ "macros",
+ "once_cell",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "static_assertions",
+ "strum",
+ "strum_macros",
+ "transcript",
 ]
 
 [[package]]
@@ -1970,9 +3023,13 @@ version = "0.1.0"
 dependencies = [
  "env_logger",
  "log",
+ "powers-of-tau",
+ "rand 0.8.5",
+ "shielder-circuits",
  "shielder-prover-common",
  "tokio",
  "tokio-vsock",
+ "type-conversions",
 ]
 
 [[package]]
@@ -2037,8 +3094,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
- "rand_core",
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2198,7 +3255,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -2215,7 +3272,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "rust_decimal",
  "serde",
@@ -2259,7 +3316,7 @@ dependencies = [
  "memchr",
  "num-bigint",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -2337,6 +3394,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,6 +3458,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2436,6 +3519,15 @@ checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2617,10 +3709,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "transcript"
+version = "0.2.0"
+source = "git+https://github.com/Cardinal-Cryptography/zkOS-circuits?rev=df31437#df314375b3fc0dad87a0e2805ff3c616b1794f35"
+dependencies = [
+ "halo2_proofs",
+ "itertools 0.13.0",
+ "ruint",
+ "sha3 0.10.8",
+]
+
+[[package]]
+name = "type-conversions"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "halo2curves",
+ "thiserror",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
@@ -2648,6 +3784,12 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
@@ -2684,6 +3826,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,10 +3854,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasite"
@@ -3002,6 +4168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,6 +4267,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "zerotrie"

--- a/tee/Cargo.toml
+++ b/tee/Cargo.toml
@@ -18,6 +18,7 @@ clap = "4.5.38"
 env_logger = "0.11.8"
 futures = "0.3.31"
 log = "0.4.27"
+rand = { version = "0.8.5" }
 sea-orm = "1.1.11"
 serde = "1.0.219"
 serde_json = "1.0.140"
@@ -29,3 +30,10 @@ tokio-task-pool = "0.1.5"
 tokio-util = "0.7.15"
 tokio-vsock = "0.7.1"
 vsock = "0.5.1"
+
+shielder-circuits = { git = "https://github.com/Cardinal-Cryptography/zkOS-circuits", rev = "df31437" }
+
+# This is not ideal - one workspace depends on another, but as long as it reproducibly produces
+# the same measurements, we are good
+type-conversions = { path = "../crates/type-conversions" }
+powers-of-tau = { path = "../crates/powers-of-tau" }

--- a/tee/crates/shielder-prover-common/src/protocol.rs
+++ b/tee/crates/shielder-prover-common/src/protocol.rs
@@ -14,5 +14,5 @@ pub enum Response {
     Pong,
 }
 
-pub type RewardServer = VsockServer<Request, Response>;
-pub type RewardClient = VsockClient<Request, Response>;
+pub type ProverServer = VsockServer<Request, Response>;
+pub type ProverClient = VsockClient<Request, Response>;

--- a/tee/crates/shielder-prover-server/src/main.rs
+++ b/tee/crates/shielder-prover-server/src/main.rs
@@ -3,7 +3,7 @@ use std::{sync::Arc, time::Duration};
 use axum::{extract::State, http::StatusCode, routing::get, serve, Json, Router};
 use clap::Parser;
 use log::{debug, error};
-use shielder_prover_common::protocol::{Request, Response, RewardClient, VSOCK_PORT};
+use shielder_prover_common::protocol::{Request, Response, ProverClient, VSOCK_PORT};
 use thiserror::Error;
 use tokio::net::TcpListener;
 
@@ -78,7 +78,7 @@ async fn health(State(state): State<Arc<AppState>>) -> Result<(), StatusCode> {
 async fn request(state: Arc<AppState>, request: Request) -> Result<Json<Response>, StatusCode> {
     debug!("Sending TEE request: {:?}", request);
 
-    let mut tee_client = RewardClient::new(state.options.tee_cid, VSOCK_PORT)
+    let mut tee_client = ProverClient::new(state.options.tee_cid, VSOCK_PORT)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let response = tee_client

--- a/tee/crates/shielder-prover-tee/Cargo.toml
+++ b/tee/crates/shielder-prover-tee/Cargo.toml
@@ -19,3 +19,11 @@ tokio = { workspace = true, features = [
     "time",
 ] }
 tokio-vsock = { workspace = true }
+shielder-circuits = { workspace = true }
+rand = { workspace = true }
+type-conversions = { workspace = true }
+
+[build-dependencies]
+powers-of-tau = { workspace = true }
+rand = { workspace = true, features = ["small_rng"] }
+shielder-circuits = { workspace = true }

--- a/tee/crates/shielder-prover-tee/build.rs
+++ b/tee/crates/shielder-prover-tee/build.rs
@@ -1,0 +1,62 @@
+//! This file has been copied from crates/shielder_bindings/build.rs
+
+//! This script builds artifacts, which are later
+//! embedded into the wasm binary.
+//! To speedup the build process, we cache the artifacts after the first build.
+//!
+//! When working locally, the `artifacts/` directory should be cleaned after the circuits are changed.
+use powers_of_tau::{get_ptau_file_path, read as read_setup_parameters, Format};
+use shielder_circuits::{
+    circuits::Params,
+    deposit::DepositCircuit,
+    generate_keys_with_min_k,
+    marshall::{marshall_params, marshall_pk},
+    new_account::NewAccountCircuit,
+    withdraw::WithdrawCircuit,
+    Circuit, Fr, MAX_K,
+};
+
+/// This function is used to generate the artifacts for the circuit, i.e. hardcoded keys
+/// and parameters. Saves results to `params.bin` and `pk.bin`.
+fn gen_params_pk<C: Circuit<Fr> + Default>(circuit_name: &str, full_params: &Params) {
+    std::fs::create_dir_all(format!("artifacts/{}", circuit_name))
+        .expect("Failed to create directory");
+    let (params, k, pk, _) = generate_keys_with_min_k(C::default(), full_params.clone())
+        .expect("keys should not fail to generate");
+    let params_bytes = marshall_params(&params).expect("Failed to marshall params");
+    std::fs::write(
+        format!("artifacts/{}/params.bin", circuit_name),
+        params_bytes,
+    )
+    .expect("Failed to write params.bin");
+    let key_bytes = marshall_pk(k, &pk);
+    std::fs::write(format!("artifacts/{}/pk.bin", circuit_name), key_bytes)
+        .expect("Failed to write pk.bin");
+}
+
+/// This function is used to generate the artifacts for the DepositCircuit
+fn gen_deposit(full_params: &Params) {
+    gen_params_pk::<DepositCircuit>("deposit", full_params);
+}
+
+/// This function is used to generate the artifacts for the NewAccountCircuit
+fn generate_new_account(full_params: &Params) {
+    gen_params_pk::<NewAccountCircuit>("new_account", full_params);
+}
+
+/// This function is used to generate the artifacts for the WithdrawCircuit
+fn generate_withdraw(full_params: &Params) {
+    gen_params_pk::<WithdrawCircuit>("withdraw", full_params);
+}
+
+fn main() {
+    let full_params = read_setup_parameters(
+        get_ptau_file_path(MAX_K, Format::PerpetualPowersOfTau),
+        Format::PerpetualPowersOfTau,
+    )
+    .expect("failed to read parameters from the ptau file");
+
+    gen_deposit(&full_params);
+    generate_new_account(&full_params);
+    generate_withdraw(&full_params);
+}

--- a/tee/crates/shielder-prover-tee/src/circuits/deposit.rs
+++ b/tee/crates/shielder-prover-tee/src/circuits/deposit.rs
@@ -1,0 +1,112 @@
+use std::vec::Vec;
+
+use shielder_circuits::{
+    deposit::{DepositInstance, DepositProverKnowledge},
+    Fr, PublicInputProvider,
+};
+use type_conversions::field_to_bytes;
+use crate::circuits::{vec_to_f, vec_to_path};
+
+#[derive(Clone, Debug, Default)]
+pub struct DepositPubInputsBytes {
+    pub merkle_root: Vec<u8>,
+    pub h_nullifier_old: Vec<u8>,
+    pub h_note_new: Vec<u8>,
+    pub value: Vec<u8>,
+    pub caller_address: Vec<u8>,
+    pub token_address: Vec<u8>,
+    pub mac_salt: Vec<u8>,
+    pub mac_commitment: Vec<u8>,
+}
+
+impl From<DepositProverKnowledge<Fr>> for DepositPubInputsBytes {
+    fn from(knowledge: DepositProverKnowledge<Fr>) -> Self {
+        DepositPubInputsBytes {
+            merkle_root: field_to_bytes(
+                knowledge.compute_public_input(DepositInstance::MerkleRoot),
+            ),
+            h_nullifier_old: field_to_bytes(
+                knowledge.compute_public_input(DepositInstance::HashedOldNullifier),
+            ),
+            h_note_new: field_to_bytes(
+                knowledge.compute_public_input(DepositInstance::HashedNewNote),
+            ),
+            value: field_to_bytes(knowledge.compute_public_input(DepositInstance::DepositValue)),
+            caller_address: field_to_bytes(
+                knowledge.compute_public_input(DepositInstance::CallerAddress),
+            ),
+            token_address: field_to_bytes(
+                knowledge.compute_public_input(DepositInstance::TokenAddress),
+            ),
+            mac_salt: field_to_bytes(knowledge.compute_public_input(DepositInstance::MacSalt)),
+            mac_commitment: field_to_bytes(
+                knowledge.compute_public_input(DepositInstance::MacCommitment),
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DepositCircuit(super::DepositCircuit);
+
+impl DepositCircuit {
+    pub fn new_pronto() -> Self {
+        DepositCircuit(super::DepositCircuit::new_pronto(
+            include_bytes!("../../artifacts/deposit/params.bin"),
+            include_bytes!("../../artifacts/deposit/pk.bin"),
+        ))
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DepositProveInputBytes {
+    id: Vec<u8>,
+    nullifier_old: Vec<u8>,
+    account_balance_old: Vec<u8>,
+    token_address: Vec<u8>,
+    path: Vec<u8>,
+    value: Vec<u8>,
+    caller_address: Vec<u8>,
+    nullifier_new: Vec<u8>,
+    mac_salt: Vec<u8>,
+}
+
+impl DepositCircuit {
+    pub fn prove(
+        &self,
+        deposit_prove_input_bytes: DepositProveInputBytes,
+    ) -> Vec<u8> {
+        self.0.prove(
+            &DepositProverKnowledge {
+                id: vec_to_f(deposit_prove_input_bytes.id),
+                nullifier_old: vec_to_f(deposit_prove_input_bytes.nullifier_old),
+                account_old_balance: vec_to_f(deposit_prove_input_bytes.account_balance_old),
+                token_address: vec_to_f(deposit_prove_input_bytes.token_address),
+                path: vec_to_path(deposit_prove_input_bytes.path),
+                deposit_value: vec_to_f(deposit_prove_input_bytes.value),
+                caller_address: vec_to_f(deposit_prove_input_bytes.caller_address),
+                nullifier_new: vec_to_f(deposit_prove_input_bytes.nullifier_new),
+                mac_salt: vec_to_f(deposit_prove_input_bytes.mac_salt),
+            },
+            &mut rand::thread_rng(),
+        )
+    }
+}
+
+pub fn deposit_pub_inputs(
+    deposit_prove_input_bytes: DepositProveInputBytes,
+) -> DepositPubInputsBytes {
+    let knowledge = DepositProverKnowledge {
+        id: vec_to_f(deposit_prove_input_bytes.id),
+        nullifier_old: vec_to_f(deposit_prove_input_bytes.nullifier_old),
+        account_old_balance: vec_to_f(deposit_prove_input_bytes.account_balance_old),
+        token_address: vec_to_f(deposit_prove_input_bytes.token_address),
+        path: vec_to_path(deposit_prove_input_bytes.path),
+        deposit_value: vec_to_f(deposit_prove_input_bytes.value),
+        caller_address: vec_to_f(deposit_prove_input_bytes.caller_address),
+        nullifier_new: vec_to_f(deposit_prove_input_bytes.nullifier_new),
+        mac_salt: vec_to_f(deposit_prove_input_bytes. mac_salt),
+    };
+
+    knowledge.into()
+}

--- a/tee/crates/shielder-prover-tee/src/circuits/mod.rs
+++ b/tee/crates/shielder-prover-tee/src/circuits/mod.rs
@@ -1,0 +1,134 @@
+//! this module is a copy-paste of crates/shielder_bindings/src/circuits
+//! some of the original contents were removed as target of this module is purely std
+
+use std::vec::Vec;
+use core::marker::PhantomData;
+
+use rand::RngCore;
+use shielder_circuits::{
+    circuits::{Params, ProvingKey, VerifyingKey},
+    deposit::DepositProverKnowledge,
+    generate_keys_with_min_k, generate_proof, generate_setup_params,
+    marshall::{unmarshall_params, unmarshall_pk},
+    new_account::NewAccountProverKnowledge,
+    withdraw::WithdrawProverKnowledge,
+    Fr, ProverKnowledge, PublicInputProvider, MAX_K,
+};
+use shielder_circuits::consts::merkle_constants::{ARITY, NOTE_TREE_HEIGHT};
+use type_conversions::bytes_to_field;
+
+pub mod new_account;
+pub mod deposit;
+pub mod withdraw;
+
+pub trait WasmCircuit {
+    fn decode_from_bytes(params_buf: &[u8], pk_buf: &[u8]) -> (Params, ProvingKey, u32);
+}
+
+#[derive(Clone, Debug)]
+pub struct Circuit<PK: ProverKnowledge> {
+    params: Params,
+    pk: ProvingKey,
+    vk: VerifyingKey,
+    k: u32,
+    _phantom: PhantomData<PK>,
+}
+
+macro_rules! impl_decode_bytes {
+    ($circuit_type:ty, $circuit_name:literal) => {
+        impl WasmCircuit for Circuit<$circuit_type> {
+            fn decode_from_bytes(params_buf: &[u8], pk_buf: &[u8]) -> (Params, ProvingKey, u32) {
+                let params = unmarshall_params(params_buf).expect("Failed to unmarshall params");
+
+                let (k, pk) = unmarshall_pk::<<$circuit_type as ProverKnowledge>::Circuit>(pk_buf)
+                    .expect("Failed to unmarshall pk");
+
+                (params, pk, k)
+            }
+        }
+    };
+}
+
+impl_decode_bytes!(DepositProverKnowledge<Fr>, "deposit");
+impl_decode_bytes!(NewAccountProverKnowledge<Fr>, "new_account");
+impl_decode_bytes!(WithdrawProverKnowledge<Fr>, "withdraw");
+
+impl<PK: ProverKnowledge> Circuit<PK>
+where
+    Circuit<PK>: WasmCircuit,
+{
+    pub fn k(&self) -> u32 {
+        self.k
+    }
+
+    pub fn vk(&self) -> VerifyingKey {
+        self.vk.clone()
+    }
+
+    pub fn pk(&self) -> ProvingKey {
+        self.pk.clone()
+    }
+
+    pub fn params(&self) -> Params {
+        self.params.clone()
+    }
+
+    /// Create a new DepositCircuit with hardcoded keys, which is faster than generating new keys.
+    pub fn new_pronto(params_buf: &[u8], pk_buf: &[u8]) -> Self {
+        let (params, pk, k) = Self::decode_from_bytes(params_buf, pk_buf);
+
+        let vk = pk.get_vk().clone();
+
+        Circuit {
+            params,
+            pk,
+            vk,
+            k,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn prove(&self, values: &PK, rng: &mut impl RngCore) -> Vec<u8> {
+        generate_proof(
+            &self.params,
+            &self.pk,
+            values.create_circuit(),
+            &values.serialize_public_input(),
+            rng,
+        )
+    }
+}
+
+pub type DepositCircuit = Circuit<DepositProverKnowledge<Fr>>;
+pub type NewAccountCircuit = Circuit<NewAccountProverKnowledge<Fr>>;
+pub type WithdrawCircuit = Circuit<WithdrawProverKnowledge<Fr>>;
+
+pub fn vec_to_f(v: Vec<u8>) -> Fr {
+    bytes_to_field(v).expect("failed to convert to F")
+}
+
+pub fn vec_to_path(v: Vec<u8>) -> [[Fr; ARITY]; NOTE_TREE_HEIGHT] {
+    assert_eq!(
+        NOTE_TREE_HEIGHT * ARITY * Fr::size(),
+        v.len(),
+        "Vector length must be divisible by TREE_HEIGHT * ARITY * F::size()"
+    );
+
+    let mut result = [[Fr::default(); ARITY]; NOTE_TREE_HEIGHT];
+    let mut iter = v.chunks_exact(Fr::size());
+
+    for row in result.iter_mut().take(NOTE_TREE_HEIGHT) {
+        for elem in row.iter_mut().take(ARITY) {
+            if let Some(chunk) = iter.next() {
+                *elem = Fr::from_bytes(
+                    chunk
+                        .try_into()
+                        .unwrap_or_else(|_| panic!("should be {} bytes long", Fr::size())),
+                )
+                    .expect("failed to convert to F");
+            }
+        }
+    }
+
+    result
+}

--- a/tee/crates/shielder-prover-tee/src/circuits/new_account.rs
+++ b/tee/crates/shielder-prover-tee/src/circuits/new_account.rs
@@ -1,0 +1,140 @@
+use std::vec::Vec;
+
+use shielder_circuits::{
+    field_element_to_le_bits,
+    new_account::{NewAccountInstance, NewAccountProverKnowledge},
+    Fr, GrumpkinPointAffine, PublicInputProvider,
+};
+use type_conversions::field_to_bytes;
+use crate::circuits::vec_to_f;
+
+#[derive(Clone, Debug, Default)]
+pub struct NewAccountPubInputsBytes {
+    pub hashed_note: Vec<u8>,
+    pub prenullifier: Vec<u8>,
+    pub initial_deposit: Vec<u8>,
+    pub caller_address: Vec<u8>,
+    pub token_address: Vec<u8>,
+    pub anonymity_revoker_public_key_x: Vec<u8>,
+    pub anonymity_revoker_public_key_y: Vec<u8>,
+    pub sym_key_encryption_1_x: Vec<u8>,
+    pub sym_key_encryption_1_y: Vec<u8>,
+    pub sym_key_encryption_2_x: Vec<u8>,
+    pub sym_key_encryption_2_y: Vec<u8>,
+    pub mac_salt: Vec<u8>,
+    pub mac_commitment: Vec<u8>,
+}
+
+impl From<NewAccountProverKnowledge<Fr>> for NewAccountPubInputsBytes {
+    fn from(knowledge: NewAccountProverKnowledge<Fr>) -> Self {
+        NewAccountPubInputsBytes {
+            hashed_note: field_to_bytes(
+                knowledge.compute_public_input(NewAccountInstance::HashedNote),
+            ),
+            prenullifier: field_to_bytes(
+                knowledge.compute_public_input(NewAccountInstance::Prenullifier),
+            ),
+            initial_deposit: field_to_bytes(
+                knowledge.compute_public_input(NewAccountInstance::InitialDeposit),
+            ),
+            caller_address: field_to_bytes(
+                knowledge.compute_public_input(NewAccountInstance::CallerAddress),
+            ),
+            token_address: field_to_bytes(
+                knowledge.compute_public_input(NewAccountInstance::TokenAddress),
+            ),
+            anonymity_revoker_public_key_x: field_to_bytes(
+                knowledge.compute_public_input(NewAccountInstance::AnonymityRevokerPublicKeyX),
+            ),
+            anonymity_revoker_public_key_y: field_to_bytes(
+                knowledge.compute_public_input(NewAccountInstance::AnonymityRevokerPublicKeyY),
+            ),
+            sym_key_encryption_1_x: field_to_bytes(
+                knowledge.compute_public_input(NewAccountInstance::EncryptedKeyCiphertext1X),
+            ),
+            sym_key_encryption_1_y: field_to_bytes(
+                knowledge.compute_public_input(NewAccountInstance::EncryptedKeyCiphertext1Y),
+            ),
+            sym_key_encryption_2_x: field_to_bytes(
+                knowledge.compute_public_input(NewAccountInstance::EncryptedKeyCiphertext2X),
+            ),
+            sym_key_encryption_2_y: field_to_bytes(
+                knowledge.compute_public_input(NewAccountInstance::EncryptedKeyCiphertext2Y),
+            ),
+            mac_salt: field_to_bytes(knowledge.compute_public_input(NewAccountInstance::MacSalt)),
+            mac_commitment: field_to_bytes(
+                knowledge.compute_public_input(NewAccountInstance::MacCommitment),
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct NewAccountCircuit(super::NewAccountCircuit);
+
+impl NewAccountCircuit {
+    pub fn new_pronto() -> Self {
+        // this needs to be generated bu custom build.rs
+        NewAccountCircuit(super::NewAccountCircuit::new_pronto(
+            include_bytes!("../../artifacts/new_account/params.bin"),
+            include_bytes!("../../artifacts/new_account/pk.bin"),
+        ))
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct NewAccountProveInputsBytes {
+    id: Vec<u8>,
+    nullifier: Vec<u8>,
+    initial_deposit: Vec<u8>,
+    caller_address: Vec<u8>,
+    token_address: Vec<u8>,
+    encryption_salt: Vec<u8>,
+    mac_salt: Vec<u8>,
+    anonymity_revoker_public_key_x: Vec<u8>,
+    anonymity_revoker_public_key_y: Vec<u8>,
+}
+
+impl NewAccountCircuit {
+    pub fn prove(
+        &self,
+        new_account_bytes: NewAccountProveInputsBytes,
+    ) -> Vec<u8> {
+        self.0.prove(
+            &NewAccountProverKnowledge {
+                id: vec_to_f(new_account_bytes.id),
+                nullifier: vec_to_f(new_account_bytes.nullifier),
+                initial_deposit: vec_to_f(new_account_bytes.initial_deposit),
+                caller_address: vec_to_f(new_account_bytes.caller_address),
+                token_address: vec_to_f(new_account_bytes.token_address),
+                encryption_salt: field_element_to_le_bits(vec_to_f(new_account_bytes.encryption_salt)),
+                mac_salt: vec_to_f(new_account_bytes.mac_salt),
+                anonymity_revoker_public_key: GrumpkinPointAffine {
+                    x: vec_to_f(new_account_bytes.anonymity_revoker_public_key_x),
+                    y: vec_to_f(new_account_bytes.anonymity_revoker_public_key_y),
+                },
+            },
+            &mut rand::thread_rng(),
+        )
+    }
+}
+
+pub fn new_account_pub_inputs(
+    new_account_prove_inputs_bytes: NewAccountProveInputsBytes,
+) -> NewAccountPubInputsBytes {
+    let knowledge = NewAccountProverKnowledge {
+        id: vec_to_f(new_account_prove_inputs_bytes.id),
+        nullifier: vec_to_f(new_account_prove_inputs_bytes.nullifier),
+        initial_deposit: vec_to_f(new_account_prove_inputs_bytes.initial_deposit),
+        caller_address: vec_to_f(new_account_prove_inputs_bytes.caller_address),
+        token_address: vec_to_f(new_account_prove_inputs_bytes.token_address),
+        encryption_salt: field_element_to_le_bits(vec_to_f(new_account_prove_inputs_bytes.encryption_salt)),
+        mac_salt: vec_to_f(new_account_prove_inputs_bytes.mac_salt),
+        anonymity_revoker_public_key: GrumpkinPointAffine {
+            x: vec_to_f(new_account_prove_inputs_bytes.anonymity_revoker_public_key_x),
+            y: vec_to_f(new_account_prove_inputs_bytes.anonymity_revoker_public_key_y),
+        },
+    };
+
+    knowledge.into()
+}

--- a/tee/crates/shielder-prover-tee/src/circuits/withdraw.rs
+++ b/tee/crates/shielder-prover-tee/src/circuits/withdraw.rs
@@ -1,0 +1,114 @@
+use std::vec::Vec;
+
+use shielder_circuits::{
+    withdraw::{WithdrawInstance, WithdrawProverKnowledge},
+    Fr, PublicInputProvider,
+};
+use type_conversions::field_to_bytes;
+use crate::circuits::{vec_to_f, vec_to_path};
+
+#[derive(Clone, Debug, Default)]
+pub struct WithdrawPubInputsBytes {
+    pub merkle_root: Vec<u8>,
+    pub h_nullifier_old: Vec<u8>,
+    pub h_note_new: Vec<u8>,
+    pub withdrawal_value: Vec<u8>,
+    pub token_address: Vec<u8>,
+    pub commitment: Vec<u8>,
+    pub mac_salt: Vec<u8>,
+    pub mac_commitment: Vec<u8>,
+}
+
+impl From<WithdrawProverKnowledge<Fr>> for WithdrawPubInputsBytes {
+    fn from(knowledge: WithdrawProverKnowledge<Fr>) -> Self {
+        WithdrawPubInputsBytes {
+            merkle_root: field_to_bytes(
+                knowledge.compute_public_input(WithdrawInstance::MerkleRoot),
+            ),
+            h_nullifier_old: field_to_bytes(
+                knowledge.compute_public_input(WithdrawInstance::HashedOldNullifier),
+            ),
+            h_note_new: field_to_bytes(
+                knowledge.compute_public_input(WithdrawInstance::HashedNewNote),
+            ),
+            withdrawal_value: field_to_bytes(
+                knowledge.compute_public_input(WithdrawInstance::WithdrawalValue),
+            ),
+            token_address: field_to_bytes(
+                knowledge.compute_public_input(WithdrawInstance::TokenAddress),
+            ),
+            commitment: field_to_bytes(
+                knowledge.compute_public_input(WithdrawInstance::Commitment),
+            ),
+            mac_salt: field_to_bytes(knowledge.compute_public_input(WithdrawInstance::MacSalt)),
+            mac_commitment: field_to_bytes(
+                knowledge.compute_public_input(WithdrawInstance::MacCommitment),
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct WithdrawCircuit(super::WithdrawCircuit);
+
+impl WithdrawCircuit {
+    pub fn new_pronto() -> Self {
+        WithdrawCircuit(super::WithdrawCircuit::new_pronto(
+            include_bytes!("../../artifacts/withdraw/params.bin"),
+            include_bytes!("../../artifacts/withdraw/pk.bin"),
+        ))
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct WithdrawProveInputsBytes {
+    id: Vec<u8>,
+    nullifier_old: Vec<u8>,
+    account_balance_old: Vec<u8>,
+    token_address: Vec<u8>,
+    path: Vec<u8>,
+    value: Vec<u8>,
+    nullifier_new: Vec<u8>,
+    commitment: Vec<u8>,
+    mac_salt: Vec<u8>,
+}
+
+impl WithdrawCircuit {
+    pub fn prove(
+        &self,
+       withdraw_prove_inputs_bytes: WithdrawProveInputsBytes,
+    ) -> Vec<u8> {
+        self.0.prove(
+            &WithdrawProverKnowledge {
+                id: vec_to_f(withdraw_prove_inputs_bytes.id),
+                nullifier_old: vec_to_f(withdraw_prove_inputs_bytes.nullifier_old),
+                account_old_balance: vec_to_f(withdraw_prove_inputs_bytes.account_balance_old),
+                token_address: vec_to_f(withdraw_prove_inputs_bytes.token_address),
+                path: vec_to_path(withdraw_prove_inputs_bytes.path),
+                withdrawal_value: vec_to_f(withdraw_prove_inputs_bytes.value),
+                nullifier_new: vec_to_f(withdraw_prove_inputs_bytes.nullifier_new),
+                commitment: vec_to_f(withdraw_prove_inputs_bytes.commitment),
+                mac_salt: vec_to_f(withdraw_prove_inputs_bytes.mac_salt),
+            },
+            &mut rand::thread_rng(),
+        )
+    }
+}
+
+pub fn withdraw_pub_inputs(
+    withdraw_prove_inputs_bytes: WithdrawProveInputsBytes,
+) -> WithdrawPubInputsBytes {
+    let knowledge = WithdrawProverKnowledge {
+        id: vec_to_f(withdraw_prove_inputs_bytes.id),
+        nullifier_old: vec_to_f(withdraw_prove_inputs_bytes.nullifier_old),
+        account_old_balance: vec_to_f(withdraw_prove_inputs_bytes.account_balance_old),
+        token_address: vec_to_f(withdraw_prove_inputs_bytes.token_address),
+        path: vec_to_path(withdraw_prove_inputs_bytes.path),
+        withdrawal_value: vec_to_f(withdraw_prove_inputs_bytes.value),
+        nullifier_new: vec_to_f(withdraw_prove_inputs_bytes.nullifier_new),
+        commitment: vec_to_f(withdraw_prove_inputs_bytes.commitment),
+        mac_salt: vec_to_f(withdraw_prove_inputs_bytes.mac_salt),
+    };
+
+    knowledge.into()
+}

--- a/tee/crates/shielder-prover-tee/src/main.rs
+++ b/tee/crates/shielder-prover-tee/src/main.rs
@@ -1,5 +1,7 @@
+mod circuits;
+
 use log::info;
-use shielder_prover_common::protocol::{Request, Response, RewardServer, VSOCK_PORT};
+use shielder_prover_common::protocol::{Request, Response, ProverServer, VSOCK_PORT};
 use tokio::spawn;
 use tokio_vsock::{VsockAddr, VsockListener, VsockStream, VMADDR_CID_ANY};
 
@@ -27,7 +29,7 @@ async fn handle_client(stream: VsockStream) {
 }
 
 async fn do_handle_client(stream: VsockStream) -> Result<(), Box<dyn std::error::Error>> {
-    let mut server: RewardServer = stream.into();
+    let mut server: ProverServer = stream.into();
 
     loop {
         server


### PR DESCRIPTION
This is mostly a copy-paste from `shielder_bindings/src/circuits` module, modulo `shielder-prover-server` builds for std only, so all cfg attributres were removed, as well as `verify` methods. Also, `build.rs` was copied as well. Ideally, we should not copy that many files, as it increases maintenance work, in case we need to modify circuits configuration for final artifact in the future. For all "binary users" of `shielder-circuits` like `shielder-prover-server` is now, we should depend on some common code. The problem with this unification is that `shielder-bindings` are more targeted for FFI, whereas `shielder-prover-server` is targetted only for `std`. 

There's another tech debt introduced ion this PR, which is a separate cargo workspace that uses main monorepo cargo workspace. `nix build` finishes successfully, but one needs to check computed measurement file `pcr.json` is deterministic - such check will be added to CI in the future PRs.

Please note output `release` binary for `shielder-prover-server` is 2.6 MB on my machine, and `eif` file is 7MB. This is way less than `pk.bin` and `params.bin` that are 32 MB in total.
