### PR TITLE
BAC-170: Add protocol fee and memo to Shielder contract

### DIFF
--- a/contracts/ProtocolFee.sol
+++ b/contracts/ProtocolFee.sol
@@ -67,24 +67,12 @@ abstract contract ProtocolFee is Initializable {
         return $.protocolDepositFeeBps;
     }
 
-    function _computeProtocolDepositFeeFromNetAmount(
+    function _computeProtocolDepositFee(
         uint256 amount
     ) internal view returns (uint256) {
         ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
         return
             amount.mulDiv($.protocolDepositFeeBps, MAX_BPS, Math.Rounding.Ceil);
-    }
-
-    function _computeProtocolDepositFeeFromGrossAmount(
-        uint256 amount
-    ) internal view returns (uint256) {
-        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
-        return
-            amount.mulDiv(
-                $.protocolDepositFeeBps,
-                MAX_BPS + $.protocolDepositFeeBps,
-                Math.Rounding.Ceil
-            );
     }
 
     function _computeProtocolWithdrawFee(

--- a/contracts/ProtocolFee.sol
+++ b/contracts/ProtocolFee.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.26;
+
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+
+using SafeERC20 for IERC20;
+using Math for uint256;
+
+abstract contract ProtocolFee is Initializable {
+    uint256 private constant MAX_BPS = 10000;
+    uint256 private constant MAX_FEE_BPS = 500;
+
+    // keccak256(abi.encode(uint256(keccak256("zkos.storage.ProtocolFee")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant PROTOCOL_FEE_LOCATION =
+        0x9c87721c17e6235fff8083d0b9984a29270f914f1ee4a52de715ea78a62a0b00;
+
+    /// @custom:storage-location erc7201:zkos.storage.ProtocolFee
+    struct ProtocolFeeStorage {
+        uint256 protocolDepositFeeBps;
+        uint256 protocolWithdrawFeeBps;
+        address protocolFeeReceiver;
+    }
+
+    error DepositFeeTooHigh();
+    error WithdrawFeeTooHigh();
+
+    function _getProtocolFeeStorage()
+        private
+        pure
+        returns (ProtocolFeeStorage storage $)
+    {
+        assembly {
+            $.slot := PROTOCOL_FEE_LOCATION
+        }
+    }
+
+    // solhint-disable func-name-mixedcase
+    function __ProtocolFee_init(
+        uint256 _depositFeeBps,
+        uint256 _withdrawFeeBps,
+        address _protocolFeeReceiver
+    ) internal onlyInitializing {
+        require(_depositFeeBps <= MAX_FEE_BPS, DepositFeeTooHigh());
+        require(_withdrawFeeBps <= MAX_FEE_BPS, WithdrawFeeTooHigh());
+
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        $.protocolDepositFeeBps = _depositFeeBps;
+        $.protocolWithdrawFeeBps = _withdrawFeeBps;
+        $.protocolFeeReceiver = _protocolFeeReceiver;
+    }
+
+    function protocolFeeReceiver() public view returns (address) {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        return $.protocolFeeReceiver;
+    }
+
+    function protocolWithdrawFeeBps() public view returns (uint256) {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        return $.protocolWithdrawFeeBps;
+    }
+
+    function protocolDepositFeeBps() public view returns (uint256) {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        return $.protocolDepositFeeBps;
+    }
+
+    function _computeProtocolDepositFeeFromNetAmount(
+        uint256 amount
+    ) internal view returns (uint256) {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        return
+            amount.mulDiv($.protocolDepositFeeBps, MAX_BPS, Math.Rounding.Ceil);
+    }
+
+    function _computeProtocolDepositFeeFromGrossAmount(
+        uint256 amount
+    ) internal view returns (uint256) {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        return
+            amount.mulDiv(
+                $.protocolDepositFeeBps,
+                MAX_BPS + $.protocolDepositFeeBps,
+                Math.Rounding.Ceil
+            );
+    }
+
+    function _computeProtocolWithdrawFee(
+        uint256 amount
+    ) internal view returns (uint256) {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        return
+            amount.mulDiv(
+                $.protocolWithdrawFeeBps,
+                MAX_BPS,
+                Math.Rounding.Ceil
+            );
+    }
+
+    function _setProtocolFeeReceiver(address newProtocolFeeReceiver) internal {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        $.protocolFeeReceiver = newProtocolFeeReceiver;
+    }
+
+    function _setProtocolDepositFeeBps(
+        uint256 newProtocolDepositFeeBps
+    ) internal {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        require(newProtocolDepositFeeBps <= MAX_FEE_BPS, DepositFeeTooHigh());
+        $.protocolDepositFeeBps = newProtocolDepositFeeBps;
+    }
+
+    function _setProtocolWithdrawFeeBps(
+        uint256 newProtocolWithdrawFeeBps
+    ) internal {
+        ProtocolFeeStorage storage $ = _getProtocolFeeStorage();
+        require(newProtocolWithdrawFeeBps <= MAX_FEE_BPS, WithdrawFeeTooHigh());
+        $.protocolWithdrawFeeBps = newProtocolWithdrawFeeBps;
+    }
+}

--- a/contracts/Shielder.sol
+++ b/contracts/Shielder.sol
@@ -220,13 +220,13 @@ contract Shielder is
         }
 
         uint256 amount = msg.value;
-        uint256 protocolFee = _computeProtocolDepositFeeFromGrossAmount(amount);
-        amount = amount - protocolFee;
+        uint256 protocolFee = _computeProtocolDepositFee(amount);
+        uint256 netAmount = amount - protocolFee;
 
         uint256 newNoteIndex = _newAccount(
             expectedContractVersion,
             NATIVE_TOKEN_NOTE_ADDRESS,
-            amount,
+            netAmount,
             newNote,
             prenullifier,
             symKeyEncryptionC1X,
@@ -288,12 +288,13 @@ contract Shielder is
             revert ContractBalanceLimitReached();
         }
 
-        uint256 protocolFee = _computeProtocolDepositFeeFromNetAmount(amount);
+        uint256 protocolFee = _computeProtocolDepositFee(amount);
+        uint256 netAmount = amount - protocolFee;
 
         uint256 newNoteIndex = _newAccount(
             expectedContractVersion,
             tokenAddress,
-            amount,
+            netAmount,
             newNote,
             prenullifier,
             symKeyEncryptionC1X,
@@ -306,7 +307,7 @@ contract Shielder is
             memo
         );
 
-        token.safeTransferFrom(msg.sender, address(this), amount);
+        token.safeTransferFrom(msg.sender, address(this), netAmount);
         token.safeTransferFrom(msg.sender, protocolFeeReceiver(), protocolFee);
 
         emit NewAccount(
@@ -403,13 +404,13 @@ contract Shielder is
         }
 
         uint256 amount = msg.value;
-        uint256 protocolFee = _computeProtocolDepositFeeFromGrossAmount(amount);
-        amount = amount - protocolFee;
+        uint256 protocolFee = _computeProtocolDepositFee(amount);
+        uint256 netAmount = amount - protocolFee;
 
         uint256 newNoteIndex = _deposit(
             expectedContractVersion,
             NATIVE_TOKEN_NOTE_ADDRESS,
-            amount,
+            netAmount,
             oldNullifierHash,
             newNote,
             merkleRoot,
@@ -462,12 +463,13 @@ contract Shielder is
             revert ContractBalanceLimitReached();
         }
 
-        uint256 protocolFee = _computeProtocolDepositFeeFromNetAmount(amount);
+        uint256 protocolFee = _computeProtocolDepositFee(amount);
+        uint256 netAmount = amount - protocolFee;
 
         uint256 newNoteIndex = _deposit(
             expectedContractVersion,
             tokenAddress,
-            amount,
+            netAmount,
             oldNullifierHash,
             newNote,
             merkleRoot,

--- a/contracts/Shielder.sol
+++ b/contracts/Shielder.sol
@@ -36,7 +36,7 @@ contract Shielder is
     ///  - `v1` is the version of the note schema,
     ///  - `v1.v2` is the version of the circuits used,
     ///  - `v1.v2.v3` is the version of the contract itself.
-    bytes3 public constant CONTRACT_VERSION = 0x000100;
+    bytes3 public constant CONTRACT_VERSION = 0x010101;
 
     /// This amount of gas should be sufficient for ether transfers
     /// and simple fallback function execution, yet still protecting against reentrancy attack.

--- a/contracts/Shielder.sol
+++ b/contracts/Shielder.sol
@@ -354,7 +354,10 @@ contract Shielder is
         publicInputs[1] = prenullifier;
         publicInputs[2] = amount;
 
-        bytes memory commitment = abi.encodePacked(msg.sender, memo);
+        bytes memory commitment = abi.encodePacked(
+            addressToUInt256(msg.sender),
+            memo
+        );
         // @dev shifting right by 4 bits so the commitment is smaller from r
         publicInputs[3] = uint256(keccak256(commitment)) >> 4;
 
@@ -518,7 +521,10 @@ contract Shielder is
         publicInputs[2] = newNote;
         publicInputs[3] = amount;
 
-        bytes memory commitment = abi.encodePacked(msg.sender, memo);
+        bytes memory commitment = abi.encodePacked(
+            addressToUInt256(msg.sender),
+            memo
+        );
         // @dev shifting right by 4 bits so the commitment is smaller from r
         publicInputs[4] = uint256(keccak256(commitment)) >> 4;
 

--- a/scripts/Shielder.s.sol
+++ b/scripts/Shielder.s.sol
@@ -19,6 +19,12 @@ contract DeployShielderScript is Script {
         uint256 arPublicKeyX = uint256(vm.envBytes32("AR_PUBLIC_KEY_X"));
         uint256 arPublicKeyY = uint256(vm.envBytes32("AR_PUBLIC_KEY_Y"));
 
+        uint256 protocolDepositFeeBps = vm.envUint("PROTOCOL_DEPOSIT_FEE_BPS");
+        uint256 protocolWithdrawFeeBps = vm.envUint(
+            "PROTOCOL_WITHDRAW_FEE_BPS"
+        );
+        address protocolFeeReceiver = vm.envAddress("PROTOCOL_FEE_RECEIVER");
+
         bool isArbitrumChain = vm.envBool("IS_ARBITRUM_CHAIN");
 
         vm.startBroadcast(privateKey);
@@ -32,7 +38,15 @@ contract DeployShielderScript is Script {
 
         bytes memory data = abi.encodeCall(
             Shielder.initialize,
-            (owner, arPublicKeyX, arPublicKeyY, isArbitrumChain)
+            (
+                owner,
+                arPublicKeyX,
+                arPublicKeyY,
+                isArbitrumChain,
+                protocolDepositFeeBps,
+                protocolWithdrawFeeBps,
+                protocolFeeReceiver
+            )
         );
 
         address proxy = address(new ERC1967Proxy(shielderImplementation, data));

--- a/scripts/deploy-shielder.sh
+++ b/scripts/deploy-shielder.sh
@@ -12,11 +12,14 @@ function show_help {
     echo "  --help                Show this help message and exit"
     echo ""
     echo "Environment Variables:"
-    echo "  NETWORK              Target network (default: anvil)"
-    echo "  PRIVATE_KEY          Private key for deployment"
-    echo "  IS_ARBITRUM_CHAIN    Flag to indicate if the target network is Arbitrum (default: true)"
-    echo "  AR_PUBLIC_KEY        Anonymity Revoker public key as a CSV pair 'x,y'"
-    echo "  AR_SEED              Seed to generate Anonymity Revoker key pair"
+    echo "  NETWORK                     Target network (default: anvil)"
+    echo "  PRIVATE_KEY                 Private key for deployment"
+    echo "  IS_ARBITRUM_CHAIN           Flag to indicate if the target network is Arbitrum (default: true)"
+    echo "  AR_PUBLIC_KEY               Anonymity Revoker public key as a CSV pair 'x,y'"
+    echo "  AR_SEED                     Seed to generate Anonymity Revoker key pair"
+    echo "  PROTOCOL_DEPOSIT_FEE_BPS    Fee charged on the deposit amount in BPS (default: 0)"
+    echo "  PROTOCOL_WITHDRAW_FEE_BPS   Fee charged on the withdraw amount in BPS. (default: 0)"
+    echo "  PROTOCOL_FEE_RECEIVER       Receiver of the protocol fee (default: Public Address of the PRIVATE_KEY)"
     echo ""
     echo "If AR_PUBLIC_KEY is provided, it will be used directly."
     echo "If AR_SEED is provided but not AR_PUBLIC_KEY, a new key pair will be generated."
@@ -36,6 +39,9 @@ done
 NETWORK=${NETWORK:-anvil}
 OWNER_ADDRESS=$(cast wallet address ${PRIVATE_KEY})
 IS_ARBITRUM_CHAIN=${IS_ARBITRUM_CHAIN:-true}
+PROTOCOL_DEPOSIT_FEE_BPS=${PROTOCOL_DEPOSIT_FEE_BPS:-0}
+PROTOCOL_WITHDRAW_FEE_BPS=${PROTOCOL_WITHDRAW_FEE_BPS:-0}
+PROTOCOL_FEE_RECEIVER=${PROTOCOL_FEE_RECEIVER:-$OWNER_ADDRESS}
 
 # Handle AR public key
 if [ -n "${AR_PUBLIC_KEY:-}" ]; then
@@ -72,4 +78,7 @@ OWNER_ADDRESS=${OWNER_ADDRESS} \
 AR_PUBLIC_KEY_X=${AR_PUBLIC_KEY_X} \
 AR_PUBLIC_KEY_Y=${AR_PUBLIC_KEY_Y} \
 IS_ARBITRUM_CHAIN=${IS_ARBITRUM_CHAIN} \
+PROTOCOL_DEPOSIT_FEE_BPS=${PROTOCOL_DEPOSIT_FEE_BPS} \
+PROTOCOL_WITHDRAW_FEE_BPS=${PROTOCOL_WITHDRAW_FEE_BPS} \
+PROTOCOL_FEE_RECEIVER=${PROTOCOL_FEE_RECEIVER} \
 forge script DeployShielderScript --broadcast --rpc-url ${NETWORK} --sender $(cast wallet address ${PRIVATE_KEY})

--- a/test/ShielderUpgrade.t.sol
+++ b/test/ShielderUpgrade.t.sol
@@ -13,6 +13,9 @@ contract ShielderUpgrade is Test {
 
     uint256 public anonymityRevokerPubkeyX = 42;
     uint256 public anonymityRevokerPubkeyY = 43;
+    uint256 public protocolDepositFeeBps = 5;
+    uint256 public protocolWithdrawFeeBps = 5;
+    address public protocolFeeReceiver = owner;
 
     string[] public allowedErrors;
 
@@ -75,7 +78,15 @@ contract ShielderUpgrade is Test {
             "Shielder.sol:Shielder",
             abi.encodeCall(
                 Shielder.initialize,
-                (owner, anonymityRevokerPubkeyX, anonymityRevokerPubkeyY, false)
+                (
+                    owner,
+                    anonymityRevokerPubkeyX,
+                    anonymityRevokerPubkeyY,
+                    false,
+                    protocolDepositFeeBps,
+                    protocolWithdrawFeeBps,
+                    protocolFeeReceiver
+                )
             )
         );
         Shielder shielder = Shielder(shielderProxy);


### PR DESCRIPTION
### Add protocol fee to the deposit and withdrawal actions.

`newAccount` / `deposit` protocol fee:
 - Applied over the `msg.value`/`amount`
 - Balance of the Shielded Account is being increased by `amount - protocolFee`
   
`withdraw` fee:
  - Applied over the `msg.value`/`amount`. `relayerFee` must be greater than `amount - protocolFee`
  - Receiver gets `amount - protocolFee - relayerFee`
   
TODO: 
 - [x] Bump Shielder version
 - [x] Add "memo" bytes to the `newAccount`, `deposit`  and `withdraw`
