### PR TITLE
BAC-189: Preparations for shielder-prover-server dockerization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ measure-gas: compile-contracts
 format-rust: # Format all rust crates
 format-rust:
 	cargo +nightly fmt --all -- --check
-	cd tee && cargo +nightly fmt --all -- --check
+	cd tee && cargo fmt --all -- --check
 
 .PHONY: lint-rust
 lint-rust: # Lint all rust crates

--- a/tee/Cargo.lock
+++ b/tee/Cargo.lock
@@ -99,6 +99,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +511,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "byte-slice-cast"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +557,18 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "cipher"
@@ -637,6 +670,12 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -1300,6 +1339,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,6 +1448,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "k256"
@@ -2341,15 +2414,14 @@ name = "shielder-prover-server"
 version = "0.1.0"
 dependencies = [
  "axum",
- "base64",
  "clap",
- "log",
  "serde",
  "shielder-prover-common",
  "thiserror",
  "tokio",
  "tokio-task-pool",
  "tower-http",
+ "tracing",
  "tracing-subscriber",
  "vsock",
 ]
@@ -2734,6 +2806,7 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "chrono",
  "matchers",
  "nu-ansi-term",
  "once_cell",
@@ -2872,6 +2945,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2892,6 +3023,65 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/tee/Cargo.toml
+++ b/tee/Cargo.toml
@@ -23,7 +23,7 @@ serde = "1.0.219"
 serde_json = "1.0.140"
 shielder-prover-common = { path = "crates/shielder-prover-common" }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "chrono"] }
 thiserror = "2.0.12"
 tokio = "1.45.0"
 tokio-task-pool = "0.1.5"

--- a/tee/crates/shielder-prover-common/src/protocol.rs
+++ b/tee/crates/shielder-prover-common/src/protocol.rs
@@ -5,7 +5,7 @@ use crate::{
     vsock::{VsockClient, VsockServer},
 };
 
-pub const VSOCK_PORT: u32 = 5000;
+pub const VSOCK_PORT: u16 = 5000;
 
 /// Request to generate proof. A `payload` is encrypted `ciphertext=(pub_sk, circuit_type, circuit_inputs)`, where
 /// * `pub_sk` is a user public key, expressed as a vector of bytes, compatible with [ecies-encryption-lib](https://github.com/Cardinal-Cryptography/ecies-encryption-lib),

--- a/tee/crates/shielder-prover-server/Cargo.toml
+++ b/tee/crates/shielder-prover-server/Cargo.toml
@@ -11,13 +11,12 @@ repository = { workspace = true }
 [dependencies]
 axum = { workspace = true, features = ["tokio", "macros"] }
 clap = { workspace = true, features = ["derive"] }
-log = { workspace = true }
 serde = { workspace = true }
 shielder-prover-common = { workspace = true }
 thiserror = { workspace = true }
 tracing-subscriber = { workspace = true }
+tracing = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt", "rt-multi-thread"] }
 tokio-task-pool = { workspace = true, features = ["log"] }
 tower-http = { workspace = true, features = ["cors"] }
 vsock = { workspace = true }
-base64 = { workspace = true }

--- a/tee/crates/shielder-prover-server/src/command_line_args.rs
+++ b/tee/crates/shielder-prover-server/src/command_line_args.rs
@@ -1,6 +1,4 @@
 use clap::Parser;
-use shielder_prover_common;
-use vsock;
 
 #[derive(Parser, Debug, Clone)]
 pub struct CommandLineArgs {

--- a/tee/crates/shielder-prover-server/src/command_line_args.rs
+++ b/tee/crates/shielder-prover-server/src/command_line_args.rs
@@ -1,0 +1,42 @@
+use clap::Parser;
+use shielder_prover_common;
+use vsock;
+
+#[derive(Parser, Debug, Clone)]
+pub struct CommandLineArgs {
+    /// A port on whhich this serves listend to incoming HTTP connections.
+    #[arg(short, long, default_value = "3000")]
+    pub public_port: u16,
+
+    /// Internal port on which host and tee applications talks to each other
+    /// This is the part of the vsock endpoint, which is tee_cid:tee_port
+    #[arg(short, long, default_value_t = shielder_prover_common::protocol::VSOCK_PORT)]
+    pub tee_port: u16,
+
+    /// Local IPv4 address on which this server listens to incoming HTTP connections
+    #[arg(short, long, default_value = "0.0.0.0")]
+    pub bind_address: String,
+
+    /// A context identifier on which this server and TEE server communicate with each other
+    /// This is the part of the vsock endpoint, which is tee_cid:tee_port
+    #[clap(long, default_value_t = vsock::VMADDR_CID_HOST)]
+    pub tee_cid: u32,
+
+    /// How many incoming requests can this server handle at once
+    /// Do not raise it above 128 as this is the limit of vsock connections, at least
+    /// for the rust lib used by this server
+    #[clap(long, default_value_t = 100)]
+    pub task_pool_capacity: usize,
+
+    /// Maximum request size (in bytes) sent to server
+    #[clap(long, default_value_t = 100 * 1024)]
+    pub maximum_request_size: usize,
+
+    /// How much time this server waits for a task pool to spawn a new task
+    #[clap(long, default_value_t = 5)]
+    pub task_pool_timeout_secs: u64,
+
+    /// How much time this server waits for a response from TEE
+    #[clap(long, default_value_t = 60)]
+    pub tee_compute_timeout_secs: u64,
+}

--- a/tee/crates/shielder-prover-server/src/error.rs
+++ b/tee/crates/shielder-prover-server/src/error.rs
@@ -2,7 +2,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response as AxumResponse},
 };
-use log::error;
+use tracing::error;
 use shielder_prover_common::vsock::VsockError;
 use tokio::task::JoinError;
 

--- a/tee/crates/shielder-prover-server/src/error.rs
+++ b/tee/crates/shielder-prover-server/src/error.rs
@@ -26,19 +26,19 @@ impl IntoResponse for ShielderProverServerError {
         let (status, error_message) = match &self {
             ShielderProverServerError::Io(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Internal I/O error: {:?}", e),
+                format!("Internal I/O error: {e:?}"),
             ),
             ShielderProverServerError::TaskPool(e) => (
                 StatusCode::GATEWAY_TIMEOUT,
-                format!("Cannot schedule more tasks: {:?}", e),
+                format!("Cannot schedule more tasks: {e:?}"),
             ),
             ShielderProverServerError::ProvingServerError(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("TEE Proving Server error: {:?}", e),
+                format!("TEE Proving Server error: {e:?}"),
             ),
             ShielderProverServerError::JoinHandleError(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Servers task failed to completion : {:?}", e),
+                format!("Servers task failed to completion : {e:?}"),
             ),
         };
 

--- a/tee/crates/shielder-prover-server/src/error.rs
+++ b/tee/crates/shielder-prover-server/src/error.rs
@@ -2,9 +2,9 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response as AxumResponse},
 };
-use tracing::error;
 use shielder_prover_common::vsock::VsockError;
 use tokio::task::JoinError;
+use tracing::error;
 
 #[derive(thiserror::Error, Debug)]
 pub enum ShielderProverServerError {

--- a/tee/crates/shielder-prover-server/src/handlers/generate_proof.rs
+++ b/tee/crates/shielder-prover-server/src/handlers/generate_proof.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use axum::{extract::State, response::IntoResponse, Json};
+use tracing::instrument;
 use shielder_prover_common::protocol::Request;
 
 use crate::{
@@ -8,6 +9,8 @@ use crate::{
     handlers::{request, GenerateProofPayload},
     AppState,
 };
+
+#[instrument(level = "trace")]
 pub async fn generate_proof(
     State(state): State<Arc<AppState>>,
     Json(generate_proof_payload): Json<GenerateProofPayload>,

--- a/tee/crates/shielder-prover-server/src/handlers/generate_proof.rs
+++ b/tee/crates/shielder-prover-server/src/handlers/generate_proof.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use axum::{extract::State, response::IntoResponse, Json};
-use tracing::instrument;
 use shielder_prover_common::protocol::Request;
+use tracing::instrument;
 
 use crate::{
     error::ShielderProverServerError,

--- a/tee/crates/shielder-prover-server/src/handlers/health.rs
+++ b/tee/crates/shielder-prover-server/src/handlers/health.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 
 use axum::{extract::State, Json};
 use shielder_prover_common::protocol::{Request, Response};
-
+use tracing::{instrument};
 use crate::{error::ShielderProverServerError, handlers::request, AppState};
 
-#[axum::debug_handler]
+#[instrument(level = "trace")]
 pub async fn health(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<Response>, ShielderProverServerError> {

--- a/tee/crates/shielder-prover-server/src/handlers/health.rs
+++ b/tee/crates/shielder-prover-server/src/handlers/health.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use axum::{extract::State, Json};
 use shielder_prover_common::protocol::{Request, Response};
-use tracing::{instrument};
+use tracing::instrument;
+
 use crate::{error::ShielderProverServerError, handlers::request, AppState};
 
 #[instrument(level = "trace")]

--- a/tee/crates/shielder-prover-server/src/handlers/mod.rs
+++ b/tee/crates/shielder-prover-server/src/handlers/mod.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use axum::Json;
-use tracing::debug;
 use serde::{Deserialize, Serialize};
 use shielder_prover_common::{
     base64_serialization,
     protocol::{ProverClient, Request, Response},
     vsock::VsockError,
 };
+use tracing::debug;
 
 use crate::AppState;
 
@@ -18,7 +18,8 @@ pub mod tee_public_key;
 async fn request(state: Arc<AppState>, request: Request) -> Result<Json<Response>, VsockError> {
     debug!("Sending TEE request: {:?}", request);
 
-    let mut tee_client = ProverClient::new(state.options.tee_cid, state.options.tee_port as u32).await?;
+    let mut tee_client =
+        ProverClient::new(state.options.tee_cid, state.options.tee_port as u32).await?;
     let response = tee_client.request(&request).await?;
 
     debug!("Got TEE response: {:?}", response);

--- a/tee/crates/shielder-prover-server/src/handlers/mod.rs
+++ b/tee/crates/shielder-prover-server/src/handlers/mod.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
 use axum::Json;
-use log::debug;
+use tracing::debug;
 use serde::{Deserialize, Serialize};
 use shielder_prover_common::{
     base64_serialization,
-    protocol::{ProverClient, Request, Response, VSOCK_PORT},
+    protocol::{ProverClient, Request, Response},
     vsock::VsockError,
 };
 
@@ -18,7 +18,7 @@ pub mod tee_public_key;
 async fn request(state: Arc<AppState>, request: Request) -> Result<Json<Response>, VsockError> {
     debug!("Sending TEE request: {:?}", request);
 
-    let mut tee_client = ProverClient::new(state.options.tee_cid, VSOCK_PORT).await?;
+    let mut tee_client = ProverClient::new(state.options.tee_cid, state.options.tee_port as u32).await?;
     let response = tee_client.request(&request).await?;
 
     debug!("Got TEE response: {:?}", response);

--- a/tee/crates/shielder-prover-server/src/handlers/tee_public_key.rs
+++ b/tee/crates/shielder-prover-server/src/handlers/tee_public_key.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use axum::{extract::State, Json};
-use tracing::instrument;
 use shielder_prover_common::protocol::{Request, Response};
+use tracing::instrument;
 
 use crate::{error::ShielderProverServerError, handlers::request, AppState};
 

--- a/tee/crates/shielder-prover-server/src/handlers/tee_public_key.rs
+++ b/tee/crates/shielder-prover-server/src/handlers/tee_public_key.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
 use axum::{extract::State, Json};
+use tracing::instrument;
 use shielder_prover_common::protocol::{Request, Response};
 
 use crate::{error::ShielderProverServerError, handlers::request, AppState};
 
-#[axum::debug_handler]
+#[instrument(level = "trace")]
 pub async fn tee_public_key(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<Response>, ShielderProverServerError> {

--- a/tee/crates/shielder-prover-server/src/main.rs
+++ b/tee/crates/shielder-prover-server/src/main.rs
@@ -1,6 +1,6 @@
+mod command_line_args;
 mod error;
 mod handlers;
-mod command_line_args;
 
 use std::{sync::Arc, time::Duration};
 
@@ -9,17 +9,14 @@ use axum::{
     routing::{get, post},
     serve, Router,
 };
-
-use error::ShielderProverServerError as Error;
 use clap::Parser;
+use error::ShielderProverServerError as Error;
 use tokio::net::TcpListener;
 use tower_http::cors::CorsLayer;
 use tracing::info;
-use tracing_subscriber::{fmt, EnvFilter};
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
-use crate::command_line_args::CommandLineArgs;
-use crate::handlers as server_handlers;
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+use crate::{command_line_args::CommandLineArgs, handlers as server_handlers};
 
 #[derive(Debug)]
 struct AppState {
@@ -30,10 +27,7 @@ struct AppState {
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     tracing_subscriber::registry()
-        .with(
-            EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| EnvFilter::new("info")),
-        )
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
         .with(
             fmt::layer()
                 .with_ansi(true)

--- a/tee/crates/shielder-prover-tee/build.rs
+++ b/tee/crates/shielder-prover-tee/build.rs
@@ -19,18 +19,18 @@ use shielder_circuits::{
 /// This function is used to generate the artifacts for the circuit, i.e. hardcoded keys
 /// and parameters. Saves results to `params.bin` and `pk.bin`.
 fn gen_params_pk<C: Circuit<Fr> + Default>(circuit_name: &str, full_params: &Params) {
-    std::fs::create_dir_all(format!("artifacts/{}", circuit_name))
+    std::fs::create_dir_all(format!("artifacts/{circuit_name}"))
         .expect("Failed to create directory");
     let (params, k, pk, _) = generate_keys_with_min_k(C::default(), full_params.clone())
         .expect("keys should not fail to generate");
     let params_bytes = marshall_params(&params).expect("Failed to marshall params");
     std::fs::write(
-        format!("artifacts/{}/params.bin", circuit_name),
+        format!("artifacts/{circuit_name}/params.bin"),
         params_bytes,
     )
     .expect("Failed to write params.bin");
     let key_bytes = marshall_pk(k, &pk);
-    std::fs::write(format!("artifacts/{}/pk.bin", circuit_name), key_bytes)
+    std::fs::write(format!("artifacts/{circuit_name}/pk.bin"), key_bytes)
         .expect("Failed to write pk.bin");
 }
 

--- a/tee/crates/shielder-prover-tee/build.rs
+++ b/tee/crates/shielder-prover-tee/build.rs
@@ -24,11 +24,8 @@ fn gen_params_pk<C: Circuit<Fr> + Default>(circuit_name: &str, full_params: &Par
     let (params, k, pk, _) = generate_keys_with_min_k(C::default(), full_params.clone())
         .expect("keys should not fail to generate");
     let params_bytes = marshall_params(&params).expect("Failed to marshall params");
-    std::fs::write(
-        format!("artifacts/{circuit_name}/params.bin"),
-        params_bytes,
-    )
-    .expect("Failed to write params.bin");
+    std::fs::write(format!("artifacts/{circuit_name}/params.bin"), params_bytes)
+        .expect("Failed to write params.bin");
     let key_bytes = marshall_pk(k, &pk);
     std::fs::write(format!("artifacts/{circuit_name}/pk.bin"), key_bytes)
         .expect("Failed to write pk.bin");

--- a/tee/crates/shielder-prover-tee/src/server.rs
+++ b/tee/crates/shielder-prover-tee/src/server.rs
@@ -32,8 +32,8 @@ pub struct Server {
 }
 
 impl Server {
-    pub fn new(port: u32) -> Result<Arc<Self>, VsockError> {
-        let address = VsockAddr::new(VMADDR_CID_ANY, port);
+    pub fn new(port: u16) -> Result<Arc<Self>, VsockError> {
+        let address = VsockAddr::new(VMADDR_CID_ANY, port as u32);
         let listener = VsockListener::bind(address)?;
         info!("Generating server's asymmetric keys...");
 

--- a/tee/crates/shielder-prover-tee/src/server.rs
+++ b/tee/crates/shielder-prover-tee/src/server.rs
@@ -69,7 +69,7 @@ impl Server {
     }
     pub async fn handle_client(self: Arc<Self>, stream: VsockStream) {
         let result = self.do_handle_client(stream).await;
-        debug!("Client disconnected: {:?}", result);
+        debug!("Client disconnected: {result:?}");
     }
 
     async fn do_handle_client(&self, stream: VsockStream) -> Result<(), VsockError> {

--- a/tee/crates/shielder-prover-tee/src/server.rs
+++ b/tee/crates/shielder-prover-tee/src/server.rs
@@ -131,10 +131,10 @@ impl Server {
     ) -> Result<(Vec<u8>, Vec<u8>), VsockError> {
         let decrypted_payload = self.decrypt_using_servers_private_key(&request_payload)?;
 
-        let decrypted_payload = str::from_utf8(&decrypted_payload).map_err(|_| {
+        let decrypted_payload = String::from_utf8(decrypted_payload).map_err(|_| {
             VsockError::Protocol(String::from("Failed to decode decrypted payload as UTF-8."))
         })?;
-        let deserialized_payload: Payload = serde_json::from_str(decrypted_payload)?;
+        let deserialized_payload: Payload = serde_json::from_str(&decrypted_payload)?;
 
         let (proof, pub_inputs) = Self::compute_proof(
             &deserialized_payload.circuit_inputs,

--- a/tee/nix/flake.lock
+++ b/tee/nix/flake.lock
@@ -151,16 +151,16 @@
     "zkOS-monorepo": {
       "flake": false,
       "locked": {
-        "lastModified": 1751455595,
-        "narHash": "sha256-9rdyw9yyeMQ0mP+xYohDfktkJ/wAzz2KSvUnXP55Upo=",
+        "lastModified": 1752656551,
+        "narHash": "sha256-RZume0ig/eNs+BvqT3uh3VWfa8b1z0qBUh5g+Knvsyg=",
         "ref": "refs/heads/main",
-        "rev": "1852b2809325e1e089def6dbdf34c03640c06c0c",
-        "revCount": 220,
+        "rev": "374a0d5dea2128e9b5100ede6daecc9253a241d9",
+        "revCount": 233,
         "type": "git",
         "url": "https://github.com/Cardinal-Cryptography/zkOS-monorepo"
       },
       "original": {
-        "rev": "1852b2809325e1e089def6dbdf34c03640c06c0c",
+        "rev": "374a0d5dea2128e9b5100ede6daecc9253a241d9",
         "type": "git",
         "url": "https://github.com/Cardinal-Cryptography/zkOS-monorepo"
       }

--- a/tee/nix/flake.nix
+++ b/tee/nix/flake.nix
@@ -27,7 +27,7 @@
 
       craneLib = (crane.mkLib pkgs).overrideToolchain (
         p:
-        p.rust-bin.stable.latest.default.override {
+        p.rust-bin.stable."1.88.0".default.override {
           targets = [ "x86_64-unknown-linux-musl" ];
         }
       );

--- a/tee/rust-toolchain.toml
+++ b/tee/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy", "rust-src"]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/tee/rust-toolchain.toml
+++ b/tee/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.88.0"
 components = ["rustfmt", "clippy", "rust-src"]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/tee/rustfmt.toml
+++ b/tee/rustfmt.toml
@@ -1,0 +1,5 @@
+edition = "2021"
+use_field_init_shorthand = true
+reorder_modules = true
+
+reorder_imports = true


### PR DESCRIPTION
In `shielder-prover-server`:

* Use `tracing` logs everywhere,
* Use stable Rust channel, as now nightly is used (from parent workspace) - nix already uses `stable`
* moved config to separate file + added help
* extracted common vsock port to cmd line args, so it can be set during runtime. It does not help much since on TEE side one would need to rebuild whole image, but still I think it's worth to have it extracted 
* added TRACE full span logging, which can show how much time server spends in each handler, example log. The most interesting part is `close time.busy=9.19µs time.idle=171µs`. Also `{ permits: 100 } ` means how many concurrent task server is capable to run atm
```
2025-07-16T13:49:34.125Z TRACE health{state=AppState { options: CommandLineArgs { public_port: 3000, tee_port: 5000, bind_address: "0.0.0.0", tee_cid: 2, task_pool_capacity: 100, maximum_request_size: 102400, task_pool_timeout_secs: 5, tee_compute_timeout_secs: 60 }, task_pool: Pool { id: None, spawn_timeout: Some(5s), run_timeout: Some(60s), limiter: Some(Semaphore { ll_sem: Semaphore { permits: 100 } }), capacity: Some(100), logging_enabled: true } }}: shielder_prover_server::handlers::health: close time.busy=9.19µs time.idle=171µs
```
* `str::from_utf8` is [unstable](https://github.com/rust-lang/rust/issues/131114), changed to `String::from_utf8`
* created `rustfmt.toml` for `tee` worskpace. I think it'd be beneficial to move `tee` crates to their own repo at some point, and now it causes confusion what's really shared with the parent workspace.
* pinpoint to concrete Rust version