### PR TITLE
BAC-189: CI for Shielder Prover Server

### DIFF
--- a/.github/workflows/_build-enclave-artifacts.yml
+++ b/.github/workflows/_build-enclave-artifacts.yml
@@ -44,7 +44,10 @@ jobs:
       - name: Build enclave for shielder-prover-tee
         # yamllint disable rule:line-length
         run: |
+          mkdir out
           nix build --override-input zkOS-monorepo "github:${GITHUB_REPOSITORY}/${{ steps.get-ref-properties.outputs.full-sha }}"
+          cp result/shielderProverTEE/image.eif out/shielder-prover-tee-${{ steps.get-ref-properties.outputs.sha }}.eif
+          cp result/shielderProverTEE/pcr.json out/pcr-${{ steps.get-ref-properties.outputs.sha }}.json
 
       - name: Get artifact names
         id: get-artifact-names
@@ -56,7 +59,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.get-artifact-names.outputs.eif }}
-          path: tee/nix/result/shielderProverTEE/image.eif
+          path: tee/nix/out/shielder-prover-tee-${{ steps.get-ref-properties.outputs.sha }}.eif
           if-no-files-found: error
           retention-days: 7
 
@@ -64,6 +67,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.get-artifact-names.outputs.measurements }}
-          path: tee/nix/result/shielderProverTEE/pcr.json
+          path: tee/nix/out/pcr-${{ steps.get-ref-properties.outputs.sha }}.json
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/build-and-push-prover-server.yml
+++ b/.github/workflows/build-and-push-prover-server.yml
@@ -1,0 +1,50 @@
+---
+name: Build and push Shielder-Prover-Server docker image (host app)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'git ref: hash, branch, tag to build shielder-prover-server files from'
+        type: string
+        required: true
+
+jobs:
+  main:
+    name: Build Shielder Prover Server (host app)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Call action get-ref-properties
+        id: get-ref-properties
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v7
+
+      - name: Login to Public Amazon ECR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.ECR_PUBLIC_HOST }}
+          username: ${{ secrets.AWS_MAINNET_ECR_CC_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_MAINNET_ECR_CC_ACCESS_KEY }}
+
+      - name: DOCKER | Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.9.1
+
+      - name: Build and push docker image
+        id: build-image
+        uses: docker/build-push-action@v3
+        with:
+          context: tee
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./tee/docker/Dockerfile
+          push: true
+          tags: |
+            ${{ vars.ECR_CC_RES_PUBLIC_REGISTRY }}shielder-prover:${{ steps.get-ref-properties.outputs.sha }}
+            ${{ vars.ECR_PUBLIC_HOST }}shielder-prover:latest

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,0 +1,66 @@
+---
+name: Build and add Shielder Prover Server artifacts to GitHub Release
+
+on:
+  release:
+    types:
+      - published
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  check-vars-and-secrets:
+    name: Check vars and secrets
+    uses: ./.github/workflows/_check-vars-and-secrets.yml
+    secrets: inherit
+
+  build-enclave-artifacts:
+    name: Build enclave artifacts
+    uses: ./.github/workflows/_build-enclave-artifacts.yml
+    with:
+      ref: ${{ github.ref }}
+
+  add-ci-artifacts-to-release:
+    name: Add CI artifacts to the release
+    needs:
+      - check-vars-and-secrets
+      - build-enclave-artifacts
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Call action get-ref-properties
+        id: get-ref-properties
+        uses: Cardinal-Cryptography/github-actions/get-ref-properties@v7
+
+      - name: Download enclave artifacts - EIF
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-enclave-artifacts.outputs.artifact-name-eif }}
+          merge-multiple: true
+          path: artifacts
+
+      - name: Download enclave artifacts - Measurements
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-enclave-artifacts.outputs.artifact-name-measurements }}
+          merge-multiple: true
+          path: artifacts
+
+      - name: Generate release artifacts checksum (SHA256)
+        uses: jmgilman/actions-generate-checksum@v1
+        with:
+          output:
+            checksums.txt
+          patterns: |
+            artifacts/*
+
+      - name: Add CI artifacts to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            checksums.txt
+            artifacts/*

--- a/tee/docker/Dockerfile
+++ b/tee/docker/Dockerfile
@@ -15,10 +15,6 @@ WORKDIR /app
 
 COPY --from=builder /app/target/release/shielder-prover-server .
 
-COPY docker/dockerentrypoint.sh .
-
-RUN chmod +x dockerentrypoint.sh
-
 # Expose the default public port
 EXPOSE 3000
 


### PR DESCRIPTION
This PR adds CI for Shielder Prover Server, namely:
* `shielder-prover-server` binary is built in Docket and pushed to ECR - this is host part of the appllication. This flow was tested fully: https://github.com/Cardinal-Cryptography/zkOS-monorepo/actions/runs/16367219340/job/46247103558
* `shielder-prover-tee` is built using `nix` when a GitHub Release is Published. All part of the workflow except actual attaching files was tested https://github.com/Cardinal-Cryptography/zkOS-monorepo/actions/runs/16366263158/job/46244445623